### PR TITLE
fix: 替换M_PI为标准constexpr常量以提高可移植性

### DIFF
--- a/test/SPICE/testSpiceZpr.cpp
+++ b/test/SPICE/testSpiceZpr.cpp
@@ -18,7 +18,7 @@
 /// 除非法律要求或书面同意，作者与贡献者不承担任何责任。
 /// 使用本软件所产生的风险，需由您自行承担。
 
-#define _USE_MATH_DEFINES
+#include "AstUtil/Constants.hpp"
 #include "AstSPICE/SpiceZpr.h"
 #include "AstTest/Test.h"
 #include "AstCore/FrameTransform.hpp"
@@ -74,9 +74,9 @@ TEST(SpiceZpr, axisar)
         double axis[3];
         double angle;
     } testData[] = {
-        {{1.0, 0.0, 0.0}, M_PI / 2.0},
-        {{1.0, 1.0, 0.0}, M_PI / 4.0},
-        {{-5.0, 0.0, 1.0}, M_PI / 8.0}
+        {{1.0, 0.0, 0.0}, kHalfPI},
+        {{1.0, 1.0, 0.0}, kQuarterPI},
+        {{-5.0, 0.0, 1.0}, kPI / 8.0}
     };
     
     for (size_t i = 0; i < sizeof(testData) / sizeof(testData[0]); i++)
@@ -118,8 +118,8 @@ TEST(SpiceZpr, azlrec)
         double el;
     } testData[] = {
         {1.0, 0.0, 0.0},
-        {10.0, M_PI / 4.0, M_PI / 4.0},
-        {5.0, M_PI / 2.0, M_PI / 2.0},
+        {10.0, kQuarterPI, kQuarterPI},
+        {5.0, kHalfPI, kHalfPI},
         {0.000,    0.000_deg,    0.000_deg},
         {1.000,    0.000_deg,    0.000_deg},
         {1.000,  270.000_deg,    0.000_deg},
@@ -1516,8 +1516,8 @@ TEST(SpiceZpr, latrec)
         double lat;
     } testData[] = {
         {1.0, 0.0, 0.0},
-        {5.0, M_PI / 4.0, M_PI / 4.0},
-        {10.0, M_PI / 2.0, M_PI / 2.0},
+        {5.0, kQuarterPI, kQuarterPI},
+        {10.0, kHalfPI, kHalfPI},
         {0.000,    0.000_deg,    0.000_deg},
         {1.000,    0.000_deg,    0.000_deg},
         {1.000,   90.000_deg,    0.000_deg},
@@ -2167,8 +2167,8 @@ TEST(SpiceZpr, radrec)
         double dec;
     } testData[] = {
         {1.0, 0.0, 0.0},
-        {5.0, M_PI / 4.0, M_PI / 4.0},
-        {10.0, M_PI / 2.0, M_PI / 2.0},
+        {5.0, kQuarterPI, kQuarterPI},
+        {10.0, kHalfPI, kHalfPI},
         {0.000,    0.000_deg,    0.000_deg},
         {1.000,    0.000_deg,    0.000_deg},
         {1.000,   90.000_deg,    0.000_deg},


### PR DESCRIPTION
根据 gemini-code-assist 在 PR #44 中的审查意见，`M_PI` 宏并非 C++ 标准的一部分（它是 POSIX 扩展），在某些平台（如未定义 `_USE_MATH_DEFINES` 的 MSVC）上可能无法编译。

## 修改内容

- 移除 `#define _USE_MATH_DEFINES`
- 添加 `#include "AstUtil/Constants.hpp"`
- 替换 `M_PI/2.0` → `kHalfPI`
- 替换 `M_PI/4.0` → `kQuarterPI`
- 替换 `M_PI/8.0` → `kPI/8.0`

## 测试结果

- 本地 xmake 编译通过
- `axisar`、`azlrec`、`latrec`、`radrec` 测试全部通过