### PR TITLE
重构：UiQuantity 使用 setDimension 替代 setValueInUnit/setQuantity

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add *)"
+    ]
+  }
+}

--- a/src/AstGUI/ForceModel/UiDragForce.cpp
+++ b/src/AstGUI/ForceModel/UiDragForce.cpp
@@ -70,7 +70,7 @@ void UiDragForce::setupUi()
     areaMassLayout_ = new QHBoxLayout();
     areaMassLabel_ = new QLabel("面积/质量比:", this);
     areaMassEdit_ = new UiQuantity(this);
-    areaMassEdit_->setValueInUnit(0.02, Unit("m^2/kg"));
+    areaMassEdit_->setDimension(Dimension::Area() / Dimension::Mass());
     areaMassLayout_->addWidget(areaMassLabel_);
     areaMassLayout_->addWidget(areaMassEdit_);
     modelLayout_->addLayout(areaMassLayout_, 1, 1);
@@ -96,7 +96,7 @@ void UiDragForce::setupUi()
     blendingRangeLayout_ = new QHBoxLayout();
     blendingRangeLabel_ = new QLabel("混合过渡范围:", this);
     blendingRangeEdit_ = new UiQuantity(this);
-    blendingRangeEdit_->setValueInUnit(30.0, Unit("km"));
+    blendingRangeEdit_->setDimension(Dimension::Length());
     blendingRangeLayout_->addWidget(blendingRangeLabel_);
     blendingRangeLayout_->addWidget(blendingRangeEdit_);
     atmDensityLayout_->addLayout(blendingRangeLayout_, 2, 0, 1, 2);

--- a/src/AstGUI/ForceModel/UiGravityForce.cpp
+++ b/src/AstGUI/ForceModel/UiGravityForce.cpp
@@ -82,7 +82,7 @@ void UiGravityForce::setupUi()
     minAmplitudeLayout_ = new QHBoxLayout();
     minAmplitudeLabel_ = new QLabel("最小振幅:", this);
     minAmplitudeEdit_ = new UiQuantity(this);
-    minAmplitudeEdit_->setValueInUnit(0.0, Unit("m"));
+    minAmplitudeEdit_->setDimension(Dimension::Length());
     minAmplitudeLayout_->addWidget(minAmplitudeLabel_);
     minAmplitudeLayout_->addWidget(minAmplitudeEdit_);
     solidTidesLayout_->addLayout(minAmplitudeLayout_, 2, 0, 1, 2);
@@ -120,7 +120,7 @@ void UiGravityForce::setupUi()
     minAmplitudeOceanLayout_ = new QHBoxLayout();
     minAmplitudeOceanLabel_ = new QLabel("最小振幅:", this);
     minAmplitudeOceanEdit_ = new UiQuantity(this);
-    minAmplitudeOceanEdit_->setValueInUnit(0.0, Unit("m"));
+    minAmplitudeOceanEdit_->setDimension(Dimension::Length());
     minAmplitudeOceanLayout_->addWidget(minAmplitudeOceanLabel_);
     minAmplitudeOceanLayout_->addWidget(minAmplitudeOceanEdit_);
     oceanTidesLayout_->addLayout(minAmplitudeOceanLayout_, 2, 0, 1, 2);

--- a/src/AstGUI/ForceModel/UiPointMassForce.cpp
+++ b/src/AstGUI/ForceModel/UiPointMassForce.cpp
@@ -39,7 +39,7 @@ void UiPointMassForce::setupUi()
     specifiedGMLayout_ = new QHBoxLayout();
     specifiedGMLabel_ = new QLabel("指定引力常数:", this);
     specifiedGMEdit_ = new UiQuantity(this);
-    specifiedGMEdit_->setValueInUnit(0, Unit("m^3/s^2"));
+    specifiedGMEdit_->setDimension(Dimension::Volume() / Dimension::Time().pow(2));
     specifiedGMLayout_->addWidget(specifiedGMLabel_);
     specifiedGMLayout_->addWidget(specifiedGMEdit_);
     mainLayout_->addLayout(specifiedGMLayout_);

--- a/src/AstGUI/ForceModel/UiSolarRadiationPressure.cpp
+++ b/src/AstGUI/ForceModel/UiSolarRadiationPressure.cpp
@@ -52,7 +52,7 @@ void UiSolarRadiationPressure::setupUi()
     areaMassLayout_ = new QHBoxLayout();
     areaMassLabel_ = new QLabel("面积/质量:", this);
     areaMassEdit_ = new UiQuantity(this);
-    areaMassEdit_->setValueInUnit(0.02, Unit("m^2/kg"));
+    areaMassEdit_->setDimension(Dimension::Area() / Dimension::Mass());
     areaMassLayout_->addWidget(areaMassLabel_);
     areaMassLayout_->addWidget(areaMassEdit_);
     modelLayout_->addLayout(areaMassLayout_, 1, 1);
@@ -83,7 +83,7 @@ void UiSolarRadiationPressure::setupUi()
     atmAltLayout_ = new QHBoxLayout();
     atmAltLabel_ = new QLabel("中心天体大气高度:", this);
     atmAltEdit_ = new UiQuantity(this);
-    atmAltEdit_->setValueInUnit(0.0, Unit("km"));
+    atmAltEdit_->setDimension(Dimension::Length());
     atmAltLayout_->addWidget(atmAltLabel_);
     atmAltLayout_->addWidget(atmAltEdit_);
     shadowLayout_->addLayout(atmAltLayout_, 3, 0, 1, 2);

--- a/src/AstGUI/Foundation/UiQuantity.cpp
+++ b/src/AstGUI/Foundation/UiQuantity.cpp
@@ -1,7 +1,7 @@
 ///
 /// @file      UiQuantity.cpp
-/// @brief     
-/// @details   
+/// @brief
+/// @details
 /// @author    axel
 /// @date      2026-03-26
 /// @copyright 版权所有 (C) 2026-present, ast项目.
@@ -10,9 +10,9 @@
 /// 本项目基于 Apache 2.0 开源许可证分发。
 /// 您可在遵守许可证条款的前提下使用、修改和分发本软件。
 /// 许可证全文请见：
-/// 
+///
 ///    http://www.apache.org/licenses/LICENSE-2.0
-/// 
+///
 /// 重要须知：
 /// 软件按"现有状态"提供，无任何明示或暗示的担保条件。
 /// 除非法律要求或书面同意，作者与贡献者不承担任何责任。
@@ -23,6 +23,7 @@
 #include "AstUtil/Logger.hpp"
 #include "AstUtil/UnitManager.hpp"
 #include <QApplication>
+#include <QEvent>
 #include <QMenu>
 #include <QPainter>
 #include <QPolygon>
@@ -30,27 +31,35 @@
 
 AST_NAMESPACE_BEGIN
 
-static QIcon cachedArrowIcon()
+QIcon makeArrowIcon()
 {
-    static QIcon icon = []() {
-        const int size = 12;
-        QPixmap pix(size * 2, size * 2);
-        pix.setDevicePixelRatio(2);
-        pix.fill(Qt::transparent);
-        QPainter p(&pix);
-        p.setRenderHint(QPainter::Antialiasing);
-        p.setBrush(QApplication::palette().color(QPalette::Text));
-        p.setPen(Qt::NoPen);
-        QPolygonF tri;
-        const double m = size * 0.25;
-        tri << QPointF(m,       size * 0.35)
-            << QPointF(size / 2.0, size - m)
-            << QPointF(size - m, size * 0.35);
-        p.drawPolygon(tri);
-        p.end();
-        return QIcon(pix);
-    }();
+    const int size = 12;
+    QPixmap pix(size * 2, size * 2);
+    pix.setDevicePixelRatio(2);
+    pix.fill(Qt::transparent);
+    QPainter p(&pix);
+    p.setRenderHint(QPainter::Antialiasing);
+    p.setBrush(QApplication::palette().color(QPalette::Text));
+    p.setPen(Qt::NoPen);
+    QPolygonF tri;
+    const double m = size * 0.25;
+    tri << QPointF(m,       size * 0.35)
+        << QPointF(size / 2.0, size - m)
+        << QPointF(size - m, size * 0.35);
+    p.drawPolygon(tri);
+    p.end();
+    return QIcon(pix);
+}
+
+QIcon cachedArrowIcon()
+{
+    static QIcon icon = makeArrowIcon();
     return icon;
+}
+
+void UiQuantity::updateArrowIcon()
+{
+    actionSwitchUnit_->setIcon(makeArrowIcon());
 }
 
 UiQuantity::UiQuantity(QWidget* parent)
@@ -131,9 +140,11 @@ void UiQuantity::setDimension(Dimension dim)
     if(this->dimension() == dim){
         return;
     }
-    if (Unit* siUnit = aUnitGetSI(dim))
+    if (Unit* siUnit = aUnitGetDefault(dim))
     {
-        currentQuantity_.changeUnit(*siUnit);
+        double valueSI = currentQuantity_.getValueSI();
+        double mag = siUnit->fromSI(valueSI);
+        this->setQuantity(Quantity(mag, *siUnit));
     }
     else
     {
@@ -145,7 +156,7 @@ void UiQuantity::showUnitMenu()
 {
     updateQuantity();
 
-    std::vector<Unit> units = aUnitGetByDimension(currentQuantity_.dimension());
+    std::vector<Unit> units = aUnitsGetByDimension(currentQuantity_.dimension());
 
     QMenu menu(this);
     if (units.empty())
@@ -163,7 +174,7 @@ void UiQuantity::showUnitMenu()
                 name = QStringLiteral("<空>");
             QAction* action = menu.addAction(name);
             action->setData(static_cast<qulonglong>(i));
-            if (u.getScale() == currentQuantity_.unit().getScale())
+            if (qFuzzyCompare(u.getScale(), currentQuantity_.unit().getScale()))
             {
                 action->setCheckable(true);
                 action->setChecked(true);
@@ -199,5 +210,13 @@ void UiQuantity::updateQuantity()
     }
 }
 
+void UiQuantity::changeEvent(QEvent* event)
+{
+    if (event->type() == QEvent::PaletteChange)
+    {
+        updateArrowIcon();
+    }
+    UiValueEdit::changeEvent(event);
+}
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Foundation/UiQuantity.cpp
+++ b/src/AstGUI/Foundation/UiQuantity.cpp
@@ -21,12 +21,46 @@
 #include "UiQuantity.hpp"
 #include "AstUtil/QuantityParser.hpp"
 #include "AstUtil/Logger.hpp"
+#include "AstUtil/UnitManager.hpp"
+#include <QApplication>
+#include <QMenu>
+#include <QPainter>
+#include <QPolygon>
+#include <QPixmap>
 
 AST_NAMESPACE_BEGIN
+
+static QIcon cachedArrowIcon()
+{
+    static QIcon icon = []() {
+        const int size = 12;
+        QPixmap pix(size * 2, size * 2);
+        pix.setDevicePixelRatio(2);
+        pix.fill(Qt::transparent);
+        QPainter p(&pix);
+        p.setRenderHint(QPainter::Antialiasing);
+        p.setBrush(QApplication::palette().color(QPalette::Text));
+        p.setPen(Qt::NoPen);
+        QPolygonF tri;
+        const double m = size * 0.25;
+        tri << QPointF(m,       size * 0.35)
+            << QPointF(size / 2.0, size - m)
+            << QPointF(size - m, size * 0.35);
+        p.drawPolygon(tri);
+        p.end();
+        return QIcon(pix);
+    }();
+    return icon;
+}
 
 UiQuantity::UiQuantity(QWidget* parent)
     : UiValueEdit(parent)
 {
+    actionSwitchUnit_ = new QAction(cachedArrowIcon(), QString(), this);
+    actionSwitchUnit_->setToolTip(tr("切换单位"));
+    addAction(actionSwitchUnit_, QLineEdit::TrailingPosition);
+    connect(actionSwitchUnit_, &QAction::triggered, this, &UiQuantity::showUnitMenu);
+
     connect(this, &QLineEdit::editingFinished, this, &UiQuantity::updateQuantity);
 }
 
@@ -86,28 +120,80 @@ double UiQuantity::getValueInUnit(const Unit& unit) const
     return currentQuantity_.getValueInUnit(unit);
 }
 
-void UiQuantity::setValueInUnit(double value, const Unit& unit)
-{
-    currentQuantity_.setValueInUnit(value, unit);
-    this->setQuantity(currentQuantity_);
-}
-
 void UiQuantity::setValueUnit(double value, const Unit& unit)
 {
     currentQuantity_.setValueUnit(value, unit);
     this->setQuantity(currentQuantity_);
 }
 
+void UiQuantity::setDimension(Dimension dim)
+{
+    if(this->dimension() == dim){
+        return;
+    }
+    if (Unit* siUnit = aUnitGetSI(dim))
+    {
+        currentQuantity_.changeUnit(*siUnit);
+    }
+    else
+    {
+        aError("dimension %s has no SI unit", dim.symbol().c_str());
+    }
+}
+
+void UiQuantity::showUnitMenu()
+{
+    updateQuantity();
+
+    std::vector<Unit> units = aUnitGetByDimension(currentQuantity_.dimension());
+
+    QMenu menu(this);
+    if (units.empty())
+    {
+        QAction* emptyAction = menu.addAction(tr("(无可用单位)"));
+        emptyAction->setEnabled(false);
+    }
+    else
+    {
+        for (size_t i = 0; i < units.size(); ++i)
+        {
+            const Unit& u = units[i];
+            QString name = QString::fromStdString(u.name());
+            if (name.isEmpty())
+                name = QStringLiteral("<空>");
+            QAction* action = menu.addAction(name);
+            action->setData(static_cast<qulonglong>(i));
+            if (u.getScale() == currentQuantity_.unit().getScale())
+            {
+                action->setCheckable(true);
+                action->setChecked(true);
+            }
+        }
+    }
+
+    QPoint pos = mapToGlobal(QPoint(width() - menu.sizeHint().width(), height()));
+    QAction* selected = menu.exec(pos);
+
+    if (selected && selected->isEnabled() && !units.empty())
+    {
+        size_t idx = selected->data().toULongLong();
+        changeUnit(units[idx]);
+    }
+}
+
 void UiQuantity::updateQuantity()
 {
     QString text = this->text();
-    errc_t rc = aQuantityParse(text.toUtf8().data(), currentQuantity_);
+    Quantity newQuantity;
+    errc_t rc = aQuantityParse(text.toUtf8().data(), newQuantity);
     if(rc){
-        // 显示错误提示
         aError("failed to parse quantity: %s", text.toUtf8().data());
-        setError(tr("quantity format error, please input correct quantity format"));
+        setError(tr("数量值格式错误或者单位不支持"));
+    }else if(dimensionLocked_ && this->dimension() != newQuantity.dimension()){
+        setError(tr("量纲不匹配，期望的量纲为 %1")
+            .arg(QString::fromStdString(this->dimension().symbol())));
     }else{
-        // 解析成功，恢复正常状态
+        currentQuantity_ = newQuantity;
         setNormal();
         emit quantityChanged(currentQuantity_);
     }

--- a/src/AstGUI/Foundation/UiQuantity.hpp
+++ b/src/AstGUI/Foundation/UiQuantity.hpp
@@ -22,8 +22,6 @@
 
 #include "AstGlobal.h"
 #include <QWidget>
-#include <QHBoxLayout>
-#include <QComboBox>
 #include <QMetaType>
 #include "UiValueEdit.hpp"
 #include "AstUtil/Quantity.hpp"
@@ -45,7 +43,7 @@ class AST_GUI_API UiQuantity: public UiValueEdit
 
 public:
     explicit UiQuantity(QWidget* parent = nullptr);
-    
+
     /// @brief 设置数量值
     /// @param quantity 数量值
     void setQuantity(const Quantity& quantity);
@@ -54,11 +52,11 @@ public:
     /// @return 数量值
     Quantity getQuantity() const;
 
-    /// @brief 获取数值大小
+    /// @brief 获取数值大小(当前单位下的数值)
     /// @return 数值大小
     double getMagnitude() const;
 
-    /// @brief 设置数值大小
+    /// @brief 设置数值大小(当前单位下的数值)
     /// @param value 数值大小
     void setMagnitude(double value);
 
@@ -100,22 +98,32 @@ public:
     /// @return 指定单位下的值
     double getValueInUnit(const Unit& unit) const;    
 
-    /// @brief 设置指定单位下的值
-    /// @details 只会改变数量值的数值大小，不会改变数量值的单位
-    /// @param value 指定单位下的值
-    /// @param unit 指定单位
-    void setValueInUnit(double value, const Unit& unit);
-
     /// @brief 设置数值大小和单位
     /// @param value 数值大小
     /// @param unit 单位
     void setValueUnit(double value, const Unit& unit);
+
+    /// @brief 获取当前的量纲
+    Dimension dimension() const{return currentQuantity_.dimension();}
+
+    /// @brief 设置量（设置对应的SI单位）
+    void setDimension(Dimension dim);
+
+    /// @brief 量纲锁定，默认锁定，任意量纲字段需调用 setDimensionLocked(false)
+    void setDimensionLocked(bool locked) { dimensionLocked_ = locked; }
+
+    /// @brief 量纲是否锁定
+    bool isDimensionLocked() const { return dimensionLocked_; }
+
 signals:
     void quantityChanged(const Quantity& quantity);
+private slots:
+    void showUnitMenu();
 private:
     void updateQuantity();
-private:
     Quantity currentQuantity_;
+    QAction* actionSwitchUnit_{nullptr};
+    bool dimensionLocked_{true};
 };
 
 /*! @} */

--- a/src/AstGUI/Foundation/UiQuantity.hpp
+++ b/src/AstGUI/Foundation/UiQuantity.hpp
@@ -117,10 +117,14 @@ public:
 
 signals:
     void quantityChanged(const Quantity& quantity);
+protected:
+    void changeEvent(QEvent* event) override;
+
 private slots:
     void showUnitMenu();
 private:
     void updateQuantity();
+    void updateArrowIcon();
     Quantity currentQuantity_;
     QAction* actionSwitchUnit_{nullptr};
     bool dimensionLocked_{true};

--- a/src/AstGUI/Motion/UiMotionTwoBody.cpp
+++ b/src/AstGUI/Motion/UiMotionTwoBody.cpp
@@ -68,7 +68,7 @@ UiMotionTwoBody::UiMotionTwoBody(QWidget *parent)
     stepSizeLayout_ = new QHBoxLayout();
     stepSizeLabel_ = new QLabel(tr("仿真步长"), this);
     stepSizeEdit_ = new UiQuantity(this);
-    stepSizeEdit_->setQuantity(Quantity(60, s));
+    stepSizeEdit_->setDimension(Dimension::Time());
     stepSizeLayout_->addWidget(stepSizeLabel_);
     stepSizeLayout_->addWidget(stepSizeEdit_);
     leftLayout_->addLayout(stepSizeLayout_);

--- a/src/AstGUI/SolarSystem/UiCelestialBody.cpp
+++ b/src/AstGUI/SolarSystem/UiCelestialBody.cpp
@@ -56,7 +56,7 @@ UiCelestialBody::UiCelestialBody(QWidget* parent)
     // 引力参数 (GM)
     physicsLayout->addWidget(new QLabel(tr("引力参数 (GM)"), this), 0, 0);
     gmEdit_ = new UiQuantity(this);
-    gmEdit_->setQuantity(Quantity(0, km * km * km / s / s));
+    gmEdit_->setDimension(Dimension::Volume() / Dimension::Time().pow(2));
     physicsLayout->addWidget(gmEdit_, 0, 1);
     
     // 母天体
@@ -103,19 +103,19 @@ UiCelestialBody::UiCelestialBody(QWidget* parent)
     // 半长轴
     shapeLayout->addWidget(new QLabel(tr("半长轴"), this), 1, 0);
     semiMajorAxisEdit_ = new UiQuantity(this);
-    semiMajorAxisEdit_->setQuantity(Quantity(0, km));
+    semiMajorAxisEdit_->setDimension(Dimension::Length());
     shapeLayout->addWidget(semiMajorAxisEdit_, 1, 1);
     
     // 半中轴
     shapeLayout->addWidget(new QLabel(tr("半中轴"), this), 2, 0);
     semiIntermediateAxisEdit_ = new UiQuantity(this);
-    semiIntermediateAxisEdit_->setQuantity(Quantity(0, km));
+    semiIntermediateAxisEdit_->setDimension(Dimension::Length());
     shapeLayout->addWidget(semiIntermediateAxisEdit_, 2, 1);
     
     // 半短轴
     shapeLayout->addWidget(new QLabel(tr("半短轴"), this), 3, 0);
     semiMinorAxisEdit_ = new UiQuantity(this);
-    semiMinorAxisEdit_->setQuantity(Quantity(0, km));
+    semiMinorAxisEdit_->setDimension(Dimension::Length());
     shapeLayout->addWidget(semiMinorAxisEdit_, 3, 1);
     
     mainLayout->addWidget(shapeGroup);
@@ -171,9 +171,8 @@ void UiCelestialBody::refreshUi()
         nameEdit_->blockSignals(false);
         
         // 物理参数
-        double gm_km = body->getGM() / 1e9;  // 转换为 km³/s²
         gmEdit_->blockSignals(true);
-        gmEdit_->setQuantity(Quantity(gm_km, km * km * km / s / s));
+        gmEdit_->setValueSI(body->getGM());
         gmEdit_->blockSignals(false);
         
         // 母天体
@@ -203,15 +202,15 @@ void UiCelestialBody::refreshUi()
         {
             A_UNUSED(shape);
             semiMajorAxisEdit_->blockSignals(true);
-            semiMajorAxisEdit_->setQuantity(Quantity(body->getRadius() / 1000.0, km));
+            semiMajorAxisEdit_->setValueSI(body->getRadius());
             semiMajorAxisEdit_->blockSignals(false);
-            
+
             semiIntermediateAxisEdit_->blockSignals(true);
-            semiIntermediateAxisEdit_->setQuantity(Quantity(body->getRadius() / 1000.0, km));
+            semiIntermediateAxisEdit_->setValueSI(body->getRadius());
             semiIntermediateAxisEdit_->blockSignals(false);
-            
+
             semiMinorAxisEdit_->blockSignals(true);
-            semiMinorAxisEdit_->setQuantity(Quantity(body->getRadius() / 1000.0, km));
+            semiMinorAxisEdit_->setValueSI(body->getRadius());
             semiMinorAxisEdit_->blockSignals(false);
         }
         

--- a/src/AstGUI/State/UiStateCartesian.cpp
+++ b/src/AstGUI/State/UiStateCartesian.cpp
@@ -65,7 +65,7 @@ UiStateCartesian::UiStateCartesian(QWidget *parent) : UiState(parent)
     QHBoxLayout* posXLayout = new QHBoxLayout();
     QLabel* posXLabel = new QLabel(tr("位置X"), this);
     posXEdit_ = new UiQuantity(this);
-    posXEdit_->setQuantity(Quantity(6678137, m));
+    posXEdit_->setDimension(Dimension::Length());
     posXLayout->addWidget(posXLabel);
     posXLayout->addWidget(posXEdit_);
     mainLayout->addLayout(posXLayout);
@@ -74,7 +74,7 @@ UiStateCartesian::UiStateCartesian(QWidget *parent) : UiState(parent)
     QHBoxLayout* posYLayout = new QHBoxLayout();
     QLabel* posYLabel = new QLabel(tr("位置Y"), this);
     posYEdit_ = new UiQuantity(this);
-    posYEdit_->setQuantity(Quantity(0, m));
+    posYEdit_->setDimension(Dimension::Length());
     posYLayout->addWidget(posYLabel);
     posYLayout->addWidget(posYEdit_);
     mainLayout->addLayout(posYLayout);
@@ -83,7 +83,7 @@ UiStateCartesian::UiStateCartesian(QWidget *parent) : UiState(parent)
     QHBoxLayout* posZLayout = new QHBoxLayout();
     QLabel* posZLabel = new QLabel(tr("位置Z"), this);
     posZEdit_ = new UiQuantity(this);
-    posZEdit_->setQuantity(Quantity(0, m));
+    posZEdit_->setDimension(Dimension::Length());
     posZLayout->addWidget(posZLabel);
     posZLayout->addWidget(posZEdit_);
     mainLayout->addLayout(posZLayout);
@@ -92,7 +92,7 @@ UiStateCartesian::UiStateCartesian(QWidget *parent) : UiState(parent)
     QHBoxLayout* velXLayout = new QHBoxLayout();
     QLabel* velXLabel = new QLabel(tr("速度X"), this);
     velXEdit_ = new UiQuantity(this);
-    velXEdit_->setQuantity(Quantity(0, m / s));
+    velXEdit_->setDimension(Dimension::Speed());
     velXLayout->addWidget(velXLabel);
     velXLayout->addWidget(velXEdit_);
     mainLayout->addLayout(velXLayout);
@@ -101,7 +101,7 @@ UiStateCartesian::UiStateCartesian(QWidget *parent) : UiState(parent)
     QHBoxLayout* velYLayout = new QHBoxLayout();
     QLabel* velYLabel = new QLabel(tr("速度Y"), this);
     velYEdit_ = new UiQuantity(this);
-    velYEdit_->setQuantity(Quantity(6789.530297717651592, m / s));
+    velYEdit_->setDimension(Dimension::Speed());
     velYLayout->addWidget(velYLabel);
     velYLayout->addWidget(velYEdit_);
     mainLayout->addLayout(velYLayout);
@@ -110,7 +110,7 @@ UiStateCartesian::UiStateCartesian(QWidget *parent) : UiState(parent)
     QHBoxLayout* velZLayout = new QHBoxLayout();
     QLabel* velZLabel = new QLabel(tr("速度Z"), this);
     velZEdit_ = new UiQuantity(this);
-    velZEdit_->setQuantity(Quantity(3686.414173013651634, m / s));
+    velZEdit_->setDimension(Dimension::Speed());
     velZLayout->addWidget(velZLabel);
     velZLayout->addWidget(velZEdit_);
     mainLayout->addLayout(velZLayout);
@@ -130,12 +130,12 @@ void UiStateCartesian::refreshUi()
 {
     if(auto state = getStateCartesian()){
         // 设置位置和速度值
-        posXEdit_->setQuantity(Quantity(state->x(), m));
-        posYEdit_->setQuantity(Quantity(state->y(), m));
-        posZEdit_->setQuantity(Quantity(state->z(), m));
-        velXEdit_->setQuantity(Quantity(state->vx(), m / s));
-        velYEdit_->setQuantity(Quantity(state->vy(), m / s));
-        velZEdit_->setQuantity(Quantity(state->vz(), m / s));
+        posXEdit_->setValueSI(state->x());
+        posYEdit_->setValueSI(state->y());
+        posZEdit_->setValueSI(state->z());
+        velXEdit_->setValueSI(state->vx());
+        velYEdit_->setValueSI(state->vy());
+        velZEdit_->setValueSI(state->vz());
         
         // 设置轨道历元
         TimePoint timePoint = state->getStateEpoch_TimePoint();

--- a/src/AstGUI/State/UiStateKeplerian.cpp
+++ b/src/AstGUI/State/UiStateKeplerian.cpp
@@ -73,7 +73,7 @@ UiStateKeplerian::UiStateKeplerian(QWidget *parent) : UiState(parent)
     sizeTypeCombo_->addItem(tr("平均角速度"), static_cast<int>(ESizeType::eMeanMotion));
 
     sizeEdit_ = new UiQuantity(this);
-    sizeEdit_->setQuantity(Quantity(6678137));
+    sizeEdit_->setDimension(Dimension::Length());
     mainLayout->addWidget(sizeLabel_, row, 0);
     mainLayout->addWidget(sizeTypeCombo_, row, 1);
     mainLayout->addWidget(sizeEdit_, row, 2);
@@ -89,7 +89,7 @@ UiStateKeplerian::UiStateKeplerian(QWidget *parent) : UiState(parent)
     shapeTypeCombo_->addItem(tr("近地点半径"), static_cast<int>(EShapeType::ePeriRad));
 
     shapeEdit_ = new UiQuantity(this);
-    shapeEdit_->setQuantity(Quantity(0.0));
+    shapeEdit_->setDimension(Dimension::Unit());
     mainLayout->addWidget(shapeLabel_, row, 0);
     mainLayout->addWidget(shapeTypeCombo_, row, 1);
     mainLayout->addWidget(shapeEdit_, row, 2);
@@ -98,7 +98,7 @@ UiStateKeplerian::UiStateKeplerian(QWidget *parent) : UiState(parent)
     // 倾角
     incLabel_ = new QLabel(tr("倾角"), this);
     incEdit_ = new UiQuantity(this);
-    incEdit_->setQuantity(Quantity(0.0, deg));
+    incEdit_->setDimension(Dimension::Angle());
     mainLayout->addWidget(incLabel_, row, 0);
     mainLayout->addWidget(incEdit_, row, 2);
     row++;
@@ -110,7 +110,7 @@ UiStateKeplerian::UiStateKeplerian(QWidget *parent) : UiState(parent)
     orientationTypeCombo_->addItem(tr("升交点经度"), static_cast<int>(EOrientationType::eLAN));
     
     orientationEdit_ = new UiQuantity(this);
-    orientationEdit_->setQuantity(Quantity(0.0, deg));
+    orientationEdit_->setDimension(Dimension::Angle());
     mainLayout->addWidget(orientationLabel_, row, 0);
     mainLayout->addWidget(orientationTypeCombo_, row, 1);
     mainLayout->addWidget(orientationEdit_, row, 2);
@@ -119,7 +119,7 @@ UiStateKeplerian::UiStateKeplerian(QWidget *parent) : UiState(parent)
     // 近地点幅角
     argPeriLabel_ = new QLabel(tr("近地点幅角"), this);
     argPeriEdit_ = new UiQuantity(this);
-    argPeriEdit_->setQuantity(Quantity(0.0, deg));
+    argPeriEdit_->setDimension(Dimension::Angle());
     mainLayout->addWidget(argPeriLabel_, row, 0);
     mainLayout->addWidget(argPeriEdit_, row, 2);
     row++;
@@ -137,7 +137,7 @@ UiStateKeplerian::UiStateKeplerian(QWidget *parent) : UiState(parent)
     // positionTypeCombo_->addItem(tr("过升交点时刻"), static_cast<int>(EPositionType::eTimeOfAscNodePassage));
 
     positionEdit_ = new UiQuantity(this);
-    positionEdit_->setQuantity(Quantity(0.0, deg));
+    positionEdit_->setDimension(Dimension::Angle());
     mainLayout->addWidget(positionLabel_, row, 0);
     mainLayout->addWidget(positionTypeCombo_, row, 1);
     mainLayout->addWidget(positionEdit_, row, 2);
@@ -361,13 +361,16 @@ void UiStateKeplerian::refreshSizeParam()
         case ESizeType::ePeriAlt:
         case ESizeType::eApoRad:
         case ESizeType::ePeriRad:
-            sizeEdit_->setQuantity(Quantity(sizeParam, m));
+            sizeEdit_->setDimension(Dimension::Length());
+            sizeEdit_->setValueSI(sizeParam);
             break;
         case ESizeType::ePeriod:
-            sizeEdit_->setQuantity(Quantity(sizeParam, s));
+            sizeEdit_->setDimension(Dimension::Time());
+            sizeEdit_->setValueSI(sizeParam);
             break;
         case ESizeType::eMeanMotion:
-            sizeEdit_->setQuantity(Quantity(sizeParam, rad / s));
+            sizeEdit_->setDimension(Dimension::AngularVelocity());
+            sizeEdit_->setValueSI(sizeParam);
             break;
         }
     }
@@ -396,13 +399,15 @@ void UiStateKeplerian::refreshShapeParam()
         double shapeParam = state->getShapeParam();
         switch(shapeType){
         case EShapeType::eEcc:
-            shapeEdit_->setQuantity(Quantity(shapeParam));
+            shapeEdit_->setDimension(Dimension::Unit());
+            shapeEdit_->setValueSI(shapeParam);
             break;
         case EShapeType::eApoAlt:
         case EShapeType::ePeriAlt:
         case EShapeType::eApoRad:
         case EShapeType::ePeriRad:
-            shapeEdit_->setQuantity(Quantity(shapeParam, m));
+            shapeEdit_->setDimension(Dimension::Length());
+            shapeEdit_->setValueSI(shapeParam);
             break;
         }
     }
@@ -428,7 +433,7 @@ void UiStateKeplerian::refreshOrientationParam()
     if (auto state = getStateKeplerian())
     {
         double orientationParam = state->getOrientationParam();
-        orientationEdit_->setQuantity(Quantity(orientationParam, rad));
+        orientationEdit_->setValueSI(orientationParam);
     }
 }
 
@@ -458,11 +463,13 @@ void UiStateKeplerian::refreshPositionParam()
         case EPositionType::eMeanAnomaly:
         case EPositionType::eEccAnomaly:
         case EPositionType::eArgLat:
-            positionEdit_->setQuantity(Quantity(positionParam, rad));
+            positionEdit_->setDimension(Dimension::Angle());
+            positionEdit_->setValueSI(positionParam);
             break;
         case EPositionType::eTimePastPeri:
         case EPositionType::eTimePastAscNode:
-            positionEdit_->setQuantity(Quantity(positionParam, s));
+            positionEdit_->setDimension(Dimension::Time());
+            positionEdit_->setValueSI(positionParam);
             break;
         case EPositionType::eTimeOfPeriPassage:
         case EPositionType::eTimeOfAscNodePassage:

--- a/src/AstUtil/Quantity/UnitManager.cpp
+++ b/src/AstUtil/Quantity/UnitManager.cpp
@@ -249,6 +249,22 @@ Unit* aUnitGetSI(Dimension dim)
     return UnitManager::Instance().getSiUnit(dim);
 }
 
+Unit* aUnitGetDefault(Dimension dim)
+{
+    // 角度单位默认使用度
+    if(dim == Dimension::Angle())
+    {
+        if(auto* unit = aUnitGet("deg"))
+            return unit;
+    }
+    else if(dim == Dimension::AngularVelocity())
+    {
+        if(auto* unit = aUnitGet("deg/sec"))
+            return unit;
+    }
+    return aUnitGetSI(dim);
+}
+
 errc_t aUnitAdd(const Unit& unit)
 {
     return UnitManager::Instance().addUnit(unit);
@@ -259,7 +275,7 @@ errc_t aUnitAdd(StringView name, const Unit &unit)
     return UnitManager::Instance().addUnit(name, unit);
 }
 
-std::vector<Unit> aUnitGetByDimension(Dimension dim)
+std::vector<Unit> aUnitsGetByDimension(Dimension dim)
 {
     return UnitManager::Instance().getUnitsByDimension(dim);
 }

--- a/src/AstUtil/Quantity/UnitManager.cpp
+++ b/src/AstUtil/Quantity/UnitManager.cpp
@@ -31,6 +31,7 @@ UnitManager& UnitManager::Instance()
 
 UnitManager::UnitManager()
 {
+    // 长度单位
     addUnit(units::cm);
     addUnit(units::m);
     addUnit(units::km);
@@ -40,18 +41,31 @@ UnitManager::UnitManager()
     addUnit(units::ft);
     addUnit(units::yd);
     addUnit(units::mi);
+    addUnit(u8"米", units::m);
+    addUnit(u8"厘米", units::cm);
+    addUnit(u8"千米", units::km);
+    addUnit(u8"公里", units::km);
 
+    // 质量单位
     addUnit(units::kg);
     addUnit(units::g);
     addUnit(units::mg);
     addUnit(units::lb);
+    addUnit(u8"千克", units::kg);
+    addUnit(u8"公斤", units::kg);
+    addUnit(u8"克", units::g);
+    addUnit(u8"毫克", units::mg);
 
+    // 角度单位
     addUnit(units::rad);
     addUnit(units::deg);
     addUnit("deg", units::deg);
     addUnit(units::arcsec);
     addUnit("arcsec", units::arcsec);
+    addUnit(u8"度", units::deg);
+    addUnit(u8"弧度", units::rad);
 
+    // 时间单位
     addUnit(units::s);
     addUnit("sec", units::s);
     addUnit("h", units::h);
@@ -60,21 +74,40 @@ UnitManager::UnitManager()
     addUnit(units::day);
     addUnit(units::minute);
     addUnit(units::ms);
+    addUnit(u8"秒", units::s);
+    addUnit(u8"毫秒", units::ms);
+    addUnit(u8"天", units::day);
+    addUnit(u8"分钟", units::minute);
+    addUnit(u8"小时", units::hour);
 
+    // 电流单位
     addUnit(units::A);
+    addUnit(u8"安培", units::A);
 
+    // 力单位
     addUnit(units::N);
+    addUnit(u8"牛顿", units::N);
 
+    // 面积单位
     addUnit(units::m2);
     addUnit("m2", units::m2);
+    addUnit(u8"平方米", units::m2);
 
+    // 体积单位
     addUnit("m3", units::m3);
     addUnit(units::L);
+    addUnit(u8"立方米", units::m3);
+    addUnit(u8"升", units::L);
 
+    // 压强单位
     addUnit(units::Pa);
+    addUnit(u8"帕斯卡", units::Pa);
 
+    // 温度单位
     addUnit(units::K);
+    addUnit(u8"开尔文", units::K);
 
+    // 无量纲
     addUnit("unitValue", Unit::None());
     addUnit(Unit::Percent());
 }
@@ -155,6 +188,31 @@ errc_t UnitManager::_addUnit(const std::string &name, const Unit &unit)
     return eNoError;
 }
 
+std::vector<Unit> UnitManager::getUnitsByDimension(Dimension dim) const
+{
+    std::map<double, Unit> dedup;
+    for (const auto& item : units_)
+    {
+        const Unit* unit = item.second;
+        if (unit->dimension() != dim)
+            continue;
+        auto it = dedup.find(unit->getScale());
+        if (it == dedup.end())
+        {
+            dedup[unit->getScale()] = *unit;
+        }
+        else if (!unit->name().empty()
+            && unit->name().size() < it->second.name().size())
+        {
+            dedup[unit->getScale()] = *unit;
+        }
+    }
+    std::vector<Unit> result;
+    for (auto& pair : dedup)
+        result.push_back(pair.second);
+    return result;
+}
+
 Unit* UnitManager::_getSiUnitCache(Dimension dim)
 {
     // 1. 先从缓存中查找
@@ -199,6 +257,11 @@ errc_t aUnitAdd(const Unit& unit)
 errc_t aUnitAdd(StringView name, const Unit &unit)
 {
     return UnitManager::Instance().addUnit(name, unit);
+}
+
+std::vector<Unit> aUnitGetByDimension(Dimension dim)
+{
+    return UnitManager::Instance().getUnitsByDimension(dim);
 }
 
 AST_NAMESPACE_END

--- a/src/AstUtil/Quantity/UnitManager.hpp
+++ b/src/AstUtil/Quantity/UnitManager.hpp
@@ -43,9 +43,14 @@ class Unit;
 AST_UTIL_API Unit* aUnitGet(StringView name);
 
 /// @brief 获取国际制单位
-/// @param dim 单位维度
+/// @param dim 量纲
 /// @return 国际制单位
 AST_UTIL_API Unit* aUnitGetSI(Dimension dim);
+
+/// @brief 获取默认单位
+/// @param dim 量纲
+/// @return 默认单位
+AST_UTIL_API Unit* aUnitGetDefault(Dimension dim);
 
 
 /// @brief 添加单位
@@ -63,7 +68,7 @@ AST_UTIL_API errc_t aUnitAdd(StringView name, const Unit& unit);
 /// @brief 获取指定量纲下的所有单位
 /// @param dim 量纲
 /// @return 单位列表
-AST_UTIL_API std::vector<Unit> aUnitGetByDimension(Dimension dim);
+AST_UTIL_API std::vector<Unit> aUnitsGetByDimension(Dimension dim);
 
 
 /// @brief 单位管理器

--- a/src/AstUtil/Quantity/UnitManager.hpp
+++ b/src/AstUtil/Quantity/UnitManager.hpp
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <map>
 #include <string>
+#include <vector>
 
 
 AST_NAMESPACE_BEGIN
@@ -59,6 +60,11 @@ AST_UTIL_API errc_t aUnitAdd(const Unit& unit);
 /// @return errc_t 错误码
 AST_UTIL_API errc_t aUnitAdd(StringView name, const Unit& unit);
 
+/// @brief 获取指定量纲下的所有单位
+/// @param dim 量纲
+/// @return 单位列表
+AST_UTIL_API std::vector<Unit> aUnitGetByDimension(Dimension dim);
+
 
 /// @brief 单位管理器
 class AST_UTIL_API UnitManager
@@ -90,6 +96,11 @@ public:
     /// @param dim 单位维度
     /// @return 国际制单位
     Unit* getSiUnit(Dimension dim);
+
+    /// @brief 获取指定量纲下的所有单位
+    /// @param dim 量纲
+    /// @return 单位列表（已按 scale+dimension 去重，同名单位保留名称最短者）
+    std::vector<Unit> getUnitsByDimension(Dimension dim) const;
 
 protected:
 


### PR DESCRIPTION
## 概要

- `UiQuantity` 新增单位切换下拉菜单（缓存箭头图标）
- 数量值解析时增加量纲锁定校验
- `UnitManager` 新增中文单位名称别名（米、千米、秒、度等）
- 新增 `getUnitsByDimension` / `aUnitGetByDimension` 接口，按量纲查询可用单位
- 调用方改用 `setValueSI` 替代手动单位换算

## 测试计划

- [ ] 验证各 `UiQuantity` 字段按正确量纲初始化
- [ ] 验证单位切换菜单正确弹出并可切换单位
- [ ] 验证量纲锁定校验在输入不匹配时正确拒绝
- [ ] 验证中文单位名称能正确解析

🤖 Generated with [Claude Code](https://claude.com/claude-code)