### PR TITLE
feat: 添加 WASM 支持并整合 Qt 构建规则

### DIFF
--- a/projects/AppAnalyzer/xmake.lua
+++ b/projects/AppAnalyzer/xmake.lua
@@ -1,11 +1,8 @@
 target("AppAnalyzer")
-    if is_plat("wasm") then
-        add_rules("qt.widgetapp_static")
-    else
-        add_rules("qt.widgetapp")
-    end
+    add_rules("ast.qt.widgetapp")
     add_files("AppMain.cpp", "AppMain.hpp")
     add_deps("AstGUI", "AstAnalyzer")
+
     if not has_package("qt5widgets") and not is_plat("wasm") then
         set_enabled(false)
     end

--- a/projects/AppGUI/xmake.lua
+++ b/projects/AppGUI/xmake.lua
@@ -1,9 +1,5 @@
 target("AppGUI")
-    if is_plat("wasm") then
-        add_rules("qt.widgetapp_static")
-    else
-        add_rules("qt.widgetapp")
-    end
+    add_rules("ast.qt.widgetapp")
     add_files("**.cpp")
     add_files("**.hpp")
     -- add_files("**.ui")

--- a/rules.lua
+++ b/rules.lua
@@ -1,6 +1,13 @@
 rule("ast")
     on_load(function (target)
         if target:plat() == "wasm" then
+            -- 添加wasm预加载文件
+            -- 这个选项必须在on_load中设置，否则不起作用
+            target:set("values", "wasm.preloadfiles", "build/wasm/data@data")
+        end
+    end)
+    on_config(function (target)
+        if target:plat() == "wasm" then
             -- import("core.cache.localcache")
             -- local preloadfiles = localcache.get("rule.ast", "wasm.preloadfiles")
             -- if not preloadfiles then
@@ -20,8 +27,6 @@ rule("ast")
             target:add("shflags", "-s ALLOW_MEMORY_GROWTH=1")
             target:add("ldflags", "-s INITIAL_MEMORY=33554432")  -- This option was formerly calledTOTAL_MEMORY
             target:add("ldflags", "-s TOTAL_MEMORY=33554432")
-            -- 添加wasm预加载文件
-            target:set("values", "wasm.preloadfiles", "build/wasm/data@data")
         end
         local include_dir = path.join(os.scriptdir(), "include", target:name())
         if os.isdir(include_dir) then
@@ -48,5 +53,34 @@ rule("ast")
             end
         end
     end)
+rule_end()
+
+rule("ast.qt")
+    on_config(function (target)
+        target:add("frameworks", "QtWidgets", "QtGui", "QtCore", "QtSvg")
+        target:add("qt.moc.flags", "-DAST_NAMESPACE_BEGIN=namespace ast{")
+        target:add("qt.moc.flags", "-DAST_NAMESPACE_END=}")
+    end)
+rule_end()
+
+rule("ast.qt.shared")
+    add_deps("ast.qt", "qt.shared")
+rule_end()
 
 
+rule("ast.qt.widgetapp")
+    add_deps("ast.qt")
+    if is_plat("wasm") then
+        add_deps("qt.widgetapp_static")
+    else
+        add_deps("qt.widgetapp")
+    end
+    on_load(function (target)
+        -- 添加静态链接的Qt插件，必须在on_load中设置，否则不起作用
+        if target:plat() == "wasm" then
+            target:add("values", "qt.plugins", "QSvgPlugin")
+            target:add("values", "qt.links", "qsvg")
+            target:add("values", "qt.linkdirs", "plugins/imageformats")
+        end
+    end)
+rule_end()

--- a/rules.lua
+++ b/rules.lua
@@ -16,8 +16,12 @@ rule("ast")
                 target:add("ldflags", "-s ASSERTIONS=1")
                 target:add("cxflags", "-gsource-map")
             end
+            target:add("ldflags", "-s ALLOW_MEMORY_GROWTH=1")
+            target:add("shflags", "-s ALLOW_MEMORY_GROWTH=1")
+            target:add("ldflags", "-s INITIAL_MEMORY=33554432")  -- This option was formerly calledTOTAL_MEMORY
+            target:add("ldflags", "-s TOTAL_MEMORY=33554432")
             -- 添加wasm预加载文件
-            target:set("values", "wasm.preloadfiles", "build/wasm/data")
+            target:set("values", "wasm.preloadfiles", "build/wasm/data@data")
         end
         local include_dir = path.join(os.scriptdir(), "include", target:name())
         if os.isdir(include_dir) then
@@ -26,6 +30,14 @@ rule("ast")
         if target:plat() == "windows" and target:kind() == "binary" then
             -- 添加图标资源文件
             target:add("files", path.join(os.scriptdir(), "data/icons/logo/*.rc"))
+        end
+    end)
+    
+    after_config(function (target)
+        if target:plat() == "wasm" then
+            if os.exists("build/wasm/data") then
+                os.rmdir("build/wasm/data")
+            end
         end
     end)
 
@@ -37,10 +49,4 @@ rule("ast")
         end
     end)
 
-    before_clean(function (target)
-        if target:plat() == "wasm" then
-            if os.exists("build/wasm/data") then
-                os.rmdir("build/wasm/data")
-            end
-        end
-    end)
+

--- a/src/AstGUI/App/AstGUIAPI.cpp
+++ b/src/AstGUI/App/AstGUIAPI.cpp
@@ -22,7 +22,9 @@
 #include "AstGUI/UiMainWindow.hpp"
 #include "AstUtil/GUI.hpp"
 #include "AstUtil/FileSystem.hpp"
+#include "AstCore/RunTime.hpp"
 #include <QApplication>
+#include <QFontDatabase>
 #include <QStyleFactory>
 #include <QDebug>
 
@@ -51,9 +53,25 @@ errc_t aQAppInit(int argc, char *argv[])
 {
     if (aCanDisplayGUI()) {
         QApplication* app = new QApplication(argc, argv);
-        // app->setStyle(QStyleFactory::create("Fusion"));
-        // qDebug() << QStyleFactory::keys();
-        // qDebug() << QApplication::style()->metaObject()->className();
+        // 加载自带的中文字体（桌面平台作为备选，WASM 平台必需）
+        #ifdef A_WASM
+        // wasm 不会存在data目录和exe目录分离的情况，所以直接使用相对路径
+        QString fontPath = QStringLiteral("data/fonts/NotoSansSC-Regular.ttf");
+        #else
+        // 其他平台需要通过aDataDir获取data目录路径，避免其他软件调用ast库时的路径错误
+        QString fontPath = QString::fromStdString(aDataDir()) + "/fonts/NotoSansSC-Regular.ttf";
+        #endif
+        int fontId = QFontDatabase::addApplicationFont(fontPath);
+        if (fontId != -1) {
+            QStringList families = QFontDatabase::applicationFontFamilies(fontId);
+            if (!families.isEmpty()) {
+                QApplication::setFont(QFont(families.first()));
+            }
+        }
+        else
+        {
+            qDebug() << "Failed to load font from path:" << fontPath;
+        }
         (void)app;
     }else{
         QCoreApplication* app = new QCoreApplication(argc, argv);

--- a/src/AstGUI/Foundation/ObjectIcons.hpp
+++ b/src/AstGUI/Foundation/ObjectIcons.hpp
@@ -24,6 +24,7 @@
 #include <QIcon>
 #include <QCoreApplication>
 #include <QString>
+#include "AstCore/RunTime.hpp"
 
 AST_NAMESPACE_BEGIN
 
@@ -31,7 +32,13 @@ class Object;
 
 inline QIcon loadIcon(const QString& name)
 {
-    QString path = QCoreApplication::applicationDirPath() + "/data/icons/" + name + ".svg";
+    #ifdef A_WASM
+    // wasm 不会存在data目录和exe目录分离的情况，所以直接使用相对路径
+    QString path = "data/icons/" + name + ".svg";
+    #else
+    // 其他平台需要通过aDataDir获取data目录路径，避免其他软件调用ast库时的路径错误
+    QString path = QString::fromStdString(aDataDir()) + "/icons/" + name + ".svg";
+    #endif
     return QIcon(path);
 }
 

--- a/src/AstGUI/xmake.lua
+++ b/src/AstGUI/xmake.lua
@@ -1,5 +1,5 @@
 ﻿target("AstGUI")
-    add_rules("qt.shared")
+    add_rules("ast.qt.shared")
     add_files("**.cpp")
     add_files("**.hpp")
     add_files("**.ts")
@@ -7,11 +7,7 @@
     -- add_files("**.ui")
     add_headerfiles("**.hpp", {prefixdir="AstGUI"})
     add_deps("AstUtil", "AstSim", "AstCore", "AstMath", "AstAnalyzer", "AstLoader")
-    add_frameworks("QtWidgets", "QtGui", "QtCore")
     add_defines("AST_BUILD_LIB_GUI")
-    on_config(function (target)
-        target:add("qt.moc.flags", "-DAST_NAMESPACE_BEGIN=namespace ast{")
-    end)
     set_default(false)
     if not has_package("qt5widgets") and not is_plat("wasm") then
         set_enabled(false)

--- a/src/AstGUI/xmake.lua
+++ b/src/AstGUI/xmake.lua
@@ -3,6 +3,7 @@
     add_files("**.cpp")
     add_files("**.hpp")
     add_files("**.ts")
+    -- add_files("../../data/*.qrc")
     -- add_files("**.ui")
     add_headerfiles("**.hpp", {prefixdir="AstGUI"})
     add_deps("AstUtil", "AstSim", "AstCore", "AstMath", "AstAnalyzer", "AstLoader")

--- a/src/AstUtil/Platform/FileSystem.cpp
+++ b/src/AstUtil/Platform/FileSystem.cpp
@@ -87,6 +87,8 @@ std::string aGetModulePathFromAddress(void *addr)
     else {
         aError("failed to call GetModuleHandleExW");
     }
+#elif defined(A_WASM)
+    aError("WASM not support get module path from address");
 #else
     // Unix-like平台实现 (Linux, macOS等)
     Dl_info dlInfo;
@@ -161,6 +163,8 @@ std::string aExePath()
     else {
         aError("failed to call sysctl");
     }
+#elif defined(A_WASM)
+    aError("WASM not support get exe path");
 #else
     // Linux及其他Unix-like系统实现
     char buffer[PATH_MAX] = { 0 };

--- a/src/AstUtil/Platform/LibraryLoader.cpp
+++ b/src/AstUtil/Platform/LibraryLoader.cpp
@@ -19,6 +19,7 @@
  
  
 #include "LibraryLoader.hpp"
+#include "AstUtil/Logger.hpp"
 #include "AstUtil/Encode.hpp"
 #include <cstdio>
 #include <cstring>
@@ -33,6 +34,39 @@
  
 AST_NAMESPACE_BEGIN
 
+
+#ifdef A_WASM
+
+void* aLoadLibrary(const char*)
+{
+    aError("WASM not support load library");
+    return nullptr;
+}
+
+void* aGetProcAddress(void*, const char*)
+{
+    aError("WASM not support get procedure address");
+    return nullptr;
+}
+
+void* aResolveProcAddress(const char* , const char* )
+{
+    aError("WASM not support resolve procedure address");
+    return nullptr;
+}
+
+errc_t aFreeLibrary(void*)
+{
+    aError("WASM not support free library");
+    return eError;
+}
+
+const char* aGetLoadError()
+{
+    aError("WASM not support library loader");
+    return "WASM not support library loader";
+}
+#else
 
 void* _aLoadLibrary(const char* filepath)
 {
@@ -165,5 +199,7 @@ const char* aGetLoadError()
     return dlerror();
 #endif
 }
+
+#endif // A_WASM
 
 AST_NAMESPACE_END

--- a/xmake.lua
+++ b/xmake.lua
@@ -88,7 +88,7 @@ elseif is_plat("windows") then
 elseif is_plat("wasm") then         -- 编译为wasm
     -- for clang
     add_cxflags(
-        "-Wno-missing-braces"       -- 忽略警告：缺少大括号 
+        "-Wno-missing-braces"       -- 忽略警告：缺少大括号
     )
 end
 


### PR DESCRIPTION
## 概要
- 添加 WASM 平台支持，包括内存和字体加载
- 整合 Qt 构建规则，简化 AppAnalyzer 和 AppGUI 的 xmake 配置

## 测试计划
- [x] 本地构建验证 (xmake b)
- [x] CI 构建验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)