### PR TITLE
修复：初始化类成员、启用 GCC 警告及 constexpr 兼容性

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
         group: ${{ github.ref }}-${{ github.base_ref }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.arch }}-build
         cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
-          # WyriHaximus/github-action-get-previous-tag@master need it
+          # Need full history for git tag operations
           fetch-depth: 0
           submodules: true
       - uses: xmake-io/github-action-setup-xmake@v1
@@ -31,7 +31,7 @@ jobs:
 
       # Cache xmake dependencies
       - name: 配置依赖缓存
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: xmake-cache
           key: build-${{ matrix.os }}-${{ matrix.arch }}-xmake-cache-v1
@@ -82,14 +82,32 @@ jobs:
           xmake f -cy --with_test=y -m release
           xmake pack -f zip -o artifacts/ --basename=SpaceAST
       
-      - name: 获取上一个tag
-        id: previoustag
-        uses: WyriHaximus/github-action-get-previous-tag@master
+      - name: 获取发布信息
+        id: release-info
+        shell: bash
+        run: |
+          # Map runner OS to friendly name
+          case "${{ matrix.os }}" in
+            windows-*) echo "plat=windows" >> $GITHUB_OUTPUT ;;
+            ubuntu-*)  echo "plat=linux" >> $GITHUB_OUTPUT ;;
+            *)         echo "plat=${{ matrix.os }}" >> $GITHUB_OUTPUT ;;
+          esac
+          # Map arch to friendly name (x86_64 for Linux x64)
+          case "${{ matrix.os }}" in
+            ubuntu-*)
+              case "${{ matrix.arch }}" in
+                x64)   echo "arch=x86_64" >> $GITHUB_OUTPUT ;;
+                arm64) echo "arch=arm64" >> $GITHUB_OUTPUT ;;
+                *)     echo "arch=${{ matrix.arch }}" >> $GITHUB_OUTPUT ;;
+              esac ;;
+            *)
+              echo "arch=${{ matrix.arch }}" >> $GITHUB_OUTPUT ;;
+          esac
 
       - name: 上传产物
         uses: actions/upload-artifact@v4
         with:
-          name: SpaceAST-${{ matrix.os }}-${{ matrix.arch }}.zip
+          name: SpaceAST-${{ steps.release-info.outputs.plat }}-${{ steps.release-info.outputs.arch }}
           path: artifacts/SpaceAST.zip
            
       - name: 发布产物
@@ -100,15 +118,24 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: artifacts/SpaceAST.zip
-          asset_name: SpaceAST-${{ steps.previoustag.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}.zip
+          asset_name: SpaceAST-${{ github.event.release.tag_name }}-${{ steps.release-info.outputs.plat }}-${{ steps.release-info.outputs.arch }}.zip
           asset_content_type: application/zip
+      
+      - name: 更新 nightly tag
+        if: github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' && matrix.arch == 'x64'
+        shell: bash
+        run: |
+          git tag -f nightly "${{ github.sha }}"
+          git push -f origin nightly
 
-      - name: 更新dev版本的发布产物
+      - name: 更新 nightly prerelease
         if: github.ref == 'refs/heads/master'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: artifacts/SpaceAST.zip
-          asset_name: SpaceAST-dev-${{ matrix.os }}-${{ matrix.arch }}.zip
-          tag: ${{ steps.previoustag.outputs.tag }}
+          asset_name: SpaceAST-nightly-${{ steps.release-info.outputs.plat }}-${{ steps.release-info.outputs.arch }}.zip
+          tag: nightly
           overwrite: true
+          prerelease: true
+          release_name: Nightly Build

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,62 @@
+name: 标签与发布
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'xmake.lua'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: tag-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 提取版本号
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(sed -n 's/^[[:space:]]*set_version("\([0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\)".*/\1/p' xmake.lua | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "::error::无法从 xmake.lua 中提取版本号"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "已提取版本号: $VERSION → 标签: v$VERSION"
+
+      - name: 检查标签是否已存在
+        id: check_tag
+        shell: bash
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "标签 $TAG 已存在，跳过创建"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 创建标签与发布
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --target "${{ github.sha }}"
+          echo "标签与发布 $TAG 已创建"

--- a/examples/cmd/cmdHandler.cpp
+++ b/examples/cmd/cmdHandler.cpp
@@ -18,7 +18,7 @@ constexpr int find_closing(const char* s, int p) {
 
 constexpr bool is_type_impl(const char* s, int p, const char* type, int i) {
     return type[i] == '\0'
-               ? (s[p + i] == '>' || s[p + i] == ':')
+               ? ((s[p + i] == '>') | (s[p + i] == ':'))
                : (s[p + i] == type[i] && is_type_impl(s, p, type, i + 1));
 }
 

--- a/include/AstCompiler.h
+++ b/include/AstCompiler.h
@@ -352,6 +352,8 @@
         _Pragma("GCC diagnostic ignored \"-Wunused-result\"")\
         _Pragma("GCC diagnostic ignored \"-Wformat=\"")\
         _Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"")\
+        _Pragma("GCC diagnostic ignored \"-Weffc++\"")\
+        _Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")\
 
 #   define A_SUPPRESS_WARNINGS_END                           \
         _Pragma("GCC diagnostic pop")

--- a/projects/AppCrashReporter/CrashDialog.hpp
+++ b/projects/AppCrashReporter/CrashDialog.hpp
@@ -27,6 +27,9 @@ public:
     CrashDialog(const QString& logPath, const QString& appPath,
                 const QString& uploadUrl, QWidget* parent = nullptr);
 
+    CrashDialog(const CrashDialog&) = delete;
+    CrashDialog& operator=(const CrashDialog&) = delete;
+
 private slots:
     void onSendReport();
     void onRestart();
@@ -42,21 +45,21 @@ private:
     QString m_uploadUrl;
 
     // 从日志中解析的信息
-    QString m_crashType;
-    QString m_crashTime;
-    QString m_pid;
-    QStringList m_stackFrames;
+    QString m_crashType{};
+    QString m_crashTime{};
+    QString m_pid{};
+    QStringList m_stackFrames{};
 
     // UI 组件
-    QLabel* m_iconLabel;
-    QLabel* m_messageLabel;
-    QTextEdit* m_descriptionEdit;
-    QPushButton* m_detailsToggle;
-    QWidget* m_detailsPanel;
-    QLabel* m_detailsContent;
-    QPushButton* m_sendBtn;
-    QPushButton* m_restartBtn;
-    QPushButton* m_closeBtn;
+    QLabel* m_iconLabel{};
+    QLabel* m_messageLabel{};
+    QTextEdit* m_descriptionEdit{};
+    QPushButton* m_detailsToggle{};
+    QWidget* m_detailsPanel{};
+    QLabel* m_detailsContent{};
+    QPushButton* m_sendBtn{};
+    QPushButton* m_restartBtn{};
+    QPushButton* m_closeBtn{};
 
     QNetworkAccessManager* m_network;
 };

--- a/projects/AppDataUpdate/xmake.lua
+++ b/projects/AppDataUpdate/xmake.lua
@@ -1,7 +1,7 @@
 target("AppDataUpdate")
     add_rules("ast.qt.widgetapp")
     add_files("**.cpp")
-    if is_plat("windows", "mingw") then
+    if is_plat("windows") then
         add_files("AppDataUpdate.rc")
     end
     add_deps("AstUiDataUpdate", "AstCore")

--- a/rules.lua
+++ b/rules.lua
@@ -37,9 +37,10 @@ rule("ast")
             target:add("cxflags", "-Werror=uninitialized")
             target:add("cxflags", "-Werror=init-self")
             target:add("cxflags", "-Werror=maybe-uninitialized")
-            target:add("cxflags", "-Werror=effc++")
             target:add("cxflags", "-Werror=missing-field-initializers")
-            target:add("cxflags", "-Werror=reorder")
+            -- C++ 专用警告
+            target:add("cxxflags", "-Werror=effc++")
+            target:add("cxxflags", "-Werror=reorder")
         end
         if target:kind() == "binary" then
             if target:plat() == "windows" then

--- a/rules.lua
+++ b/rules.lua
@@ -32,16 +32,6 @@ rule("ast")
         if os.isdir(include_dir) then
             target:add("includedirs", include_dir)
         end
-        -- for gcc: 将一些警告转换为错误，以发现潜在的问题
-        if target:plat() == "linux" or target:plat() == "mingw" then
-            target:add("cxflags", "-Werror=uninitialized")
-            target:add("cxflags", "-Werror=init-self")
-            target:add("cxflags", "-Werror=maybe-uninitialized")
-            target:add("cxflags", "-Werror=missing-field-initializers")
-            -- C++ 专用警告
-            target:add("cxxflags", "-Werror=effc++")
-            target:add("cxxflags", "-Werror=reorder")
-        end
         if target:kind() == "binary" then
             if target:plat() == "windows" then
                 -- 添加图标资源文件

--- a/rules.lua
+++ b/rules.lua
@@ -32,6 +32,15 @@ rule("ast")
         if os.isdir(include_dir) then
             target:add("includedirs", include_dir)
         end
+        -- for gcc: 将一些警告转换为错误，以发现潜在的问题
+        if target:plat() == "linux" or target:plat() == "mingw" then
+            target:add("cxflags", "-Werror=uninitialized")
+            target:add("cxflags", "-Werror=init-self")
+            target:add("cxflags", "-Werror=maybe-uninitialized")
+            target:add("cxflags", "-Werror=effc++")
+            target:add("cxflags", "-Werror=missing-field-initializers")
+            target:add("cxflags", "-Werror=reorder")
+        end
         if target:kind() == "binary" then
             if target:plat() == "windows" then
                 -- 添加图标资源文件

--- a/src/AstAI/Agent/AgentUtil.cpp
+++ b/src/AstAI/Agent/AgentUtil.cpp
@@ -110,7 +110,7 @@ namespace{
         }
         JsonValue& json() { return json_; }
     private:
-        JsonValue internalJson_;
+        JsonValue internalJson_{}; 
         JsonValue& json_;
         int maxDepth_{0};
     };
@@ -217,7 +217,7 @@ namespace{
         }
         JsonValue& json() { return json_; }
     private:
-        JsonValue internalJson_;
+        JsonValue internalJson_{}; 
         JsonValue& json_;
         int maxDepth_{0};
     };

--- a/src/AstAI/Agent/AgentUtil.cpp
+++ b/src/AstAI/Agent/AgentUtil.cpp
@@ -45,7 +45,8 @@ namespace{
         {
         }
         PropertyVisitorImplForObjectJson(JsonValue& json, int maxDepth)
-            : json_(json)
+            : internalJson_()
+            , json_(json)
             , maxDepth_(maxDepth)
         {
         }

--- a/src/AstAI/Agent/AssistantAgent.hpp
+++ b/src/AstAI/Agent/AssistantAgent.hpp
@@ -163,11 +163,11 @@ private:
     errc_t parseResponseMessage(JsonValue& response, ChatMessage& outMessage);
 
 private:
-    std::string                    systemPrompt_;
-    ChatTools                      tools_;
-    LLMConfig                      config_;
-    std::unique_ptr<LLMClient>     client_;                 ///< LLM客户端（run()前必须设置）
-    std::string                    lastError_;              ///< 最后一次错误信息
+    std::string                    systemPrompt_{};
+    ChatTools                      tools_{};
+    LLMConfig                      config_{};
+    std::unique_ptr<LLMClient>     client_{};                 ///< LLM客户端（run()前必须设置）
+    std::string                    lastError_{};              ///< 最后一次错误信息
     int                            maxToolIterations_{10};  ///< 最大工具调用次数（默认10次）
 };
 

--- a/src/AstAI/Agent/ChatAgent.hpp
+++ b/src/AstAI/Agent/ChatAgent.hpp
@@ -61,7 +61,7 @@ public:
     const std::string& name() const { return name_; }
 
 protected:
-    std::string name_;  ///< 智能体名称
+    std::string name_{}; ///< 智能体名称
 };
 
 /*! @} */

--- a/src/AstAI/Basic/LLMConfig.hpp
+++ b/src/AstAI/Basic/LLMConfig.hpp
@@ -59,7 +59,7 @@ public:
 private:
     std::string model_ = "deepseek-v4-flash";
     float temperature_ = 0.2f;
-    JsonValue extraBody_;  ///< 提供者特有的额外请求体字段
+    JsonValue extraBody_{}; ///< 提供者特有的额外请求体字段
 };
 
 /*! @} */

--- a/src/AstAI/Chat/ChatConsole.hpp
+++ b/src/AstAI/Chat/ChatConsole.hpp
@@ -70,7 +70,7 @@ public:
 private:
     void outputText(const std::string& text);
 
-    RendererType renderer_;
+    RendererType renderer_{};
     bool     rawOutput_ = false;
 };
 

--- a/src/AstAI/Chat/ChatMessage.hpp
+++ b/src/AstAI/Chat/ChatMessage.hpp
@@ -58,7 +58,7 @@ public:
     /// @param role 消息角色
     /// @param content 消息内容
     ChatMessage(EChatRole role, StringView content)
-        : role_(role), content_(content), name_(), reasoningContent_(), toolCallId_(), toolCalls_()
+        : role_(role), name_(), content_(content), reasoningContent_(), toolCallId_(), toolCalls_()
     {}
 
     /// @brief 析构函数
@@ -150,11 +150,11 @@ public:
 
 private:
     EChatRole        role_{EChatRole::eUser};           ///< 消息角色
-    std::string      name_;                             ///< 角色名称
-    std::string      content_;                          ///< 消息内容
-    std::string      reasoningContent_;                 ///< 推理内容（当角色为ASSISTANT时使用）
-    std::string      toolCallId_;                       ///< 工具调用ID（当角色为TOOL时使用）
-    JsonValue        toolCalls_;                        ///< 工具调用列表
+    std::string      name_{};                            ///< 角色名称
+    std::string      content_{};                         ///< 消息内容
+    std::string      reasoningContent_{};                ///< 推理内容（当角色为ASSISTANT时使用）
+    std::string      toolCallId_{};                      ///< 工具调用ID（当角色为TOOL时使用）
+    JsonValue        toolCalls_{};                       ///< 工具调用列表
 };
 
 

--- a/src/AstAI/Chat/ChatMessage.hpp
+++ b/src/AstAI/Chat/ChatMessage.hpp
@@ -58,7 +58,7 @@ public:
     /// @param role 消息角色
     /// @param content 消息内容
     ChatMessage(EChatRole role, StringView content)
-        : role_(role), content_(content) 
+        : role_(role), content_(content), name_(), reasoningContent_(), toolCallId_(), toolCalls_()
     {}
 
     /// @brief 析构函数

--- a/src/AstAI/Chat/ChatSession.hpp
+++ b/src/AstAI/Chat/ChatSession.hpp
@@ -104,8 +104,8 @@ public:
     void handleToolCalls(const JsonValue& toolCalls);
 
 private:
-    mutable std::unique_ptr<AssistantAgent> agent_;     ///< 助手智能体
-    ChatMessages messages_;                             ///< 消息历史
+    mutable std::unique_ptr<AssistantAgent> agent_{};     ///< 助手智能体
+    ChatMessages messages_{};                             ///< 消息历史
 };
 
 /*! @} */

--- a/src/AstAI/Chat/Tool/ChatTool.hpp
+++ b/src/AstAI/Chat/Tool/ChatTool.hpp
@@ -75,9 +75,9 @@ public:
     /// @return JSON值
     JsonValue toJson() const;
 private:
-    std::string name_;              ///< 工具名称
-    std::string description_;       ///< 工具描述
-    JsonValue parameters_;          ///< 工具参数schema
+    std::string name_{};              ///< 工具名称
+    std::string description_{};       ///< 工具描述
+    JsonValue parameters_{};          ///< 工具参数schema
 };
 
 /// @brief 通用模板封装

--- a/src/AstAI/Chat/Tool/ChatTools.hpp
+++ b/src/AstAI/Chat/Tool/ChatTools.hpp
@@ -72,7 +72,7 @@ public:
     bool empty() const {return tools_.empty();}
 private:
     A_DISABLE_COPY(ChatTools);
-    std::vector<std::unique_ptr<ChatTool>> tools_;
+    std::vector<std::unique_ptr<ChatTool>> tools_{};
 };
 
 

--- a/src/AstAI/Providers/OpenAI.hpp
+++ b/src/AstAI/Providers/OpenAI.hpp
@@ -91,8 +91,8 @@ protected:
     const std::string& apiKey() const { return apiKey_; }
     const std::string& baseUrl() const { return baseUrl_; }
 private:
-    std::string apiKey_;          ///< API密钥
-    std::string baseUrl_;         ///< API基础URL
+    std::string apiKey_{};         ///< API密钥
+    std::string baseUrl_{};        ///< API基础URL
 };
 
 /*! @} */

--- a/src/AstAI/Providers/SSEParser.hpp
+++ b/src/AstAI/Providers/SSEParser.hpp
@@ -62,10 +62,10 @@ public:
 private:
     struct AccumulatedToolCall
     {
-        std::string id;
-        std::string type;
-        std::string functionName;
-        std::string functionArguments;
+        std::string id{};
+        std::string type{};
+        std::string functionName{};
+        std::string functionArguments{};
     };
 
     void processBuffer();

--- a/src/AstAI/Providers/SSEParser.hpp
+++ b/src/AstAI/Providers/SSEParser.hpp
@@ -74,15 +74,15 @@ private:
 
     ChatEventHandler& handler_;
     bool thoughtCompleted_{false};   // 是否已完成推理/思考内容
-    std::string       buffer_;
-    std::string       error_;
+    std::string       buffer_{};
+    std::string       error_{};
 
-    std::string id_;
-    std::string model_;
-    std::string accumulatedContent_;
-    std::string accumulatedReasoning_;
-    std::string finishReason_;
-    std::map<int, AccumulatedToolCall> toolCallsByIndex_;
+    std::string id_{};
+    std::string model_{};
+    std::string accumulatedContent_{};
+    std::string accumulatedReasoning_{};
+    std::string finishReason_{};
+    std::map<int, AccumulatedToolCall> toolCallsByIndex_{};
 };
 
 

--- a/src/AstAnalyzer/FeasibleRegion/FeasibleRegionStudy.hpp
+++ b/src/AstAnalyzer/FeasibleRegion/FeasibleRegionStudy.hpp
@@ -62,11 +62,11 @@ public:
     errc_t setValue(double value);
 
 private:
-    SharedPtr<Expr> expr_;          ///< 变量表达式
+    SharedPtr<Expr> expr_{};         ///< 变量表达式
     double lower_{};                ///< 下界
     double upper_{};                ///< 上界
     int steps_{10};                 ///< 采样点数（默认 10）
-    std::vector<double> values_;    ///< 采样值列表
+    std::vector<double> values_{};   ///< 采样值列表
 };
 
 
@@ -107,7 +107,7 @@ private:
     bool exclude_{};                ///< true: 排除区间（可行域为区间补集）; false: 包含区间（可行域为区间本身）
     double lower_{};                ///< 下界值（仅当 useLower_=true 时有效）
     double upper_{};                ///< 上界值（仅当 useUpper_=true 时有效）
-    SharedPtr<Expr> expr_;          ///< 约束表达式
+    SharedPtr<Expr> expr_{};          ///< 约束表达式
 };
 
 
@@ -160,9 +160,9 @@ public:
     errc_t executeStep(int stepIndex, bool& isFeasible);
 
 private:
-    VariableList variables_;                            ///< 变量列表
-    ConstraintList constraints_;                        ///< 约束列表
-    mutable WeakPtr<Command> relatedCommand_;           ///< 关联的执行命令
+    VariableList variables_{};                           ///< 变量列表
+    ConstraintList constraints_{};                       ///< 约束列表
+    mutable WeakPtr<Command> relatedCommand_{};          ///< 关联的执行命令
 };
 
 /*! @} */

--- a/src/AstAnalyzer/SweepStudy/SweepStudy.hpp
+++ b/src/AstAnalyzer/SweepStudy/SweepStudy.hpp
@@ -61,8 +61,8 @@ private:
     double startValue_{0.0};        ///< 变量的起始值
     double endValue_{0.0};          ///< 变量的结束值
     double stepSize_{0.0};          ///< 分析步长
-    SharedPtr<Expr> expr_;          ///< 遍历表达式
-    std::vector<double> values_;    ///< 值列表
+    SharedPtr<Expr> expr_{};         ///< 遍历表达式
+    std::vector<double> values_{};   ///< 值列表
 };
 
 
@@ -80,8 +80,8 @@ public:
     const std::vector<double>& values() const {return values_;}
 
 private:
-    SharedPtr<Expr> expr_;          ///< 结果表达式
-    std::vector<double> values_;    ///< 约束值列表
+    SharedPtr<Expr> expr_{};          ///< 结果表达式
+    std::vector<double> values_{};    ///< 约束值列表
 };
 
 
@@ -143,9 +143,9 @@ private:
     /// @brief 将步索引转换为各变量索引
     void stepIndexToVarIndices(int stepIndex, std::vector<int>& indices) const;
 
-    VariableList variables_;                            ///< 变量列表
-    OutputList outputs_;                                ///< 输出列表
-    mutable WeakPtr<Command> relatedCommand_;           ///< 关联的执行命令
+    VariableList variables_{};                            ///< 变量列表
+    OutputList outputs_{};                                ///< 输出列表
+    mutable WeakPtr<Command> relatedCommand_{};           ///< 关联的执行命令
 };
 
 /*! @} */

--- a/src/AstAnalyzer/Workbench/StudyWorkbench.hpp
+++ b/src/AstAnalyzer/Workbench/StudyWorkbench.hpp
@@ -62,9 +62,9 @@ public:
     /// @brief 获取脚本解释器
     Interpreter* interpreter() const {return interpreter_.get();}
 private:
-    VariableList inputs_;                               ///< 输入变量列表
-    VariableList outputs_;                              ///< 输出变量列表
-    mutable WeakPtr<Command> relatedCommand_;           ///< 所关联的执行命令
+    VariableList inputs_{};                               ///< 输入变量列表
+    VariableList outputs_{};                              ///< 输出变量列表
+    mutable WeakPtr<Command> relatedCommand_{};           ///< 所关联的执行命令
 private:
     mutable std::unique_ptr<Interpreter> interpreter_;  ///< 解释器
 };

--- a/src/AstChart/QWT/ColoredSurfaceEnrichment.hpp
+++ b/src/AstChart/QWT/ColoredSurfaceEnrichment.hpp
@@ -41,6 +41,8 @@ public:
     ColoredSurfaceEnrichment() = default;
     explicit ColoredSurfaceEnrichment(Qwt3D::PLOTSTYLE plotStyle)
         : plotStyle_(plotStyle) {}
+    ColoredSurfaceEnrichment(const ColoredSurfaceEnrichment&) = default;
+    ColoredSurfaceEnrichment& operator=(const ColoredSurfaceEnrichment&) = default;
     ColoredSurfaceEnrichment* clone() const override { return new ColoredSurfaceEnrichment(*this); }
     void drawBegin() override;
     void draw(Qwt3D::Triple const &) override;

--- a/src/AstChart/QWT/EditFigureDialog.cpp
+++ b/src/AstChart/QWT/EditFigureDialog.cpp
@@ -8,10 +8,12 @@
 
 #include "EditFigureDialog.hpp"
 #include "PropertyPages.hpp"
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/core/figure_type.h>
 #include <matplot/core/axes_type.h>
 #include <matplot/axes_objects/line.h>
 #include <matplot/axes_objects/surface.h>
+A_SUPPRESS_WARNINGS_END
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QSplitter>

--- a/src/AstChart/QWT/EditFigureDialog.hpp
+++ b/src/AstChart/QWT/EditFigureDialog.hpp
@@ -31,6 +31,8 @@ class AST_CHART_API EditFigureDialog : public QDialog {
     Q_OBJECT
 public:
     explicit EditFigureDialog(matplot::figure_type* figure, QWidget* parent = nullptr);
+    EditFigureDialog(const EditFigureDialog&) = delete;
+    EditFigureDialog& operator=(const EditFigureDialog&) = delete;
 
     void selectPlotItem(int axesIndex, int itemIndex);
 

--- a/src/AstChart/QWT/EditFigureDialog.hpp
+++ b/src/AstChart/QWT/EditFigureDialog.hpp
@@ -48,14 +48,14 @@ private:
     enum NodeType { TypeFigure, TypeAxes, TypePlotItem };
     enum DataRole { TypeRole = Qt::UserRole, AxesIndexRole = Qt::UserRole + 1, ItemIndexRole = Qt::UserRole + 2 };
 
-    matplot::figure_type* figure_;
-    QTreeWidget* tree_;
-    QStackedWidget* stack_;
-    AxesPropertyPage* axesPage_;
-    LinePropertyPage* linePage_;
-    SurfacePropertyPage* surfacePage_;
-    QWidget* placeholder_;
-    QPushButton* applyBtn_;
+    matplot::figure_type* figure_{};
+    QTreeWidget* tree_{};
+    QStackedWidget* stack_{};
+    AxesPropertyPage* axesPage_{};
+    LinePropertyPage* linePage_{};
+    SurfacePropertyPage* surfacePage_{};
+    QWidget* placeholder_{};
+    QPushButton* applyBtn_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstChart/QWT/PropertyPages.cpp
+++ b/src/AstChart/QWT/PropertyPages.cpp
@@ -7,10 +7,12 @@
 ///
 
 #include "PropertyPages.hpp"
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/core/axes_type.h>
 #include <matplot/core/line_spec.h>
 #include <matplot/axes_objects/line.h>
 #include <matplot/axes_objects/surface.h>
+A_SUPPRESS_WARNINGS_END
 #include <QFormLayout>
 #include <QVBoxLayout>
 #include <QGroupBox>

--- a/src/AstChart/QWT/PropertyPages.hpp
+++ b/src/AstChart/QWT/PropertyPages.hpp
@@ -29,6 +29,8 @@ class ColorButton : public QPushButton {
     Q_OBJECT
 public:
     explicit ColorButton(QWidget* parent = nullptr);
+    ColorButton(const ColorButton&) = delete;
+    ColorButton& operator=(const ColorButton&) = delete;
     QColor color() const { return color_; }
     void setColor(const QColor& c);
 signals:

--- a/src/AstChart/QWT/PropertyPages.hpp
+++ b/src/AstChart/QWT/PropertyPages.hpp
@@ -38,7 +38,7 @@ signals:
 private slots:
     void onClick();
 private:
-    QColor color_;
+    QColor color_{};
 };
 
 /// @brief 坐标轴属性编辑页
@@ -46,21 +46,32 @@ class AxesPropertyPage : public QWidget {
     Q_OBJECT
 public:
     explicit AxesPropertyPage(QWidget* parent = nullptr);
+    AxesPropertyPage(const AxesPropertyPage&) = delete;
+    AxesPropertyPage& operator=(const AxesPropertyPage&) = delete;
     void load(matplot::axes_type* axes, int index);
     void apply(matplot::axes_type* axes);
 
 private:
     void setupUi();
-    QDoubleSpinBox* posLeft_, *posBottom_, *posW_, *posH_;
-    QLineEdit* titleEdit_;
-    QComboBox* fontCombo_;
-    QDoubleSpinBox* fontSize_;
-    QDoubleSpinBox* titleFontSizeMultiplier_;
-    ColorButton* titleColorBtn_, *bgColorBtn_;
-    QLineEdit* xLabelEdit_, *yLabelEdit_;
-    QDoubleSpinBox* xMin_, *xMax_, *yMin_, *yMax_;
-    QCheckBox* xVisible_, *yVisible_;
-    QCheckBox* gridVisible_;
+    QDoubleSpinBox* posLeft_{};
+    QDoubleSpinBox* posBottom_{};
+    QDoubleSpinBox* posW_{};
+    QDoubleSpinBox* posH_{};
+    QLineEdit* titleEdit_{};
+    QComboBox* fontCombo_{};
+    QDoubleSpinBox* fontSize_{};
+    QDoubleSpinBox* titleFontSizeMultiplier_{};
+    ColorButton* titleColorBtn_{};
+    ColorButton* bgColorBtn_{};
+    QLineEdit* xLabelEdit_{};
+    QLineEdit* yLabelEdit_{};
+    QDoubleSpinBox* xMin_{};
+    QDoubleSpinBox* xMax_{};
+    QDoubleSpinBox* yMin_{};
+    QDoubleSpinBox* yMax_{};
+    QCheckBox* xVisible_{};
+    QCheckBox* yVisible_{};
+    QCheckBox* gridVisible_{};
 };
 
 /// @brief 折线/散点属性编辑页
@@ -68,19 +79,22 @@ class LinePropertyPage : public QWidget {
     Q_OBJECT
 public:
     explicit LinePropertyPage(QWidget* parent = nullptr);
+    LinePropertyPage(const LinePropertyPage&) = delete;
+    LinePropertyPage& operator=(const LinePropertyPage&) = delete;
     void load(class matplot::line* line, int index);
     void apply(class matplot::line* line);
 
 private:
     void setupUi();
-    QLineEdit* nameEdit_;
-    ColorButton* lineColorBtn_;
-    QComboBox* lineStyleCombo_;
-    QDoubleSpinBox* lineWidth_;
-    QComboBox* markerCombo_;
-    QDoubleSpinBox* markerSize_;
-    ColorButton* markerColorBtn_, *markerFaceBtn_;
-    QCheckBox* visibleCheck_;
+    QLineEdit* nameEdit_{};
+    ColorButton* lineColorBtn_{};
+    QComboBox* lineStyleCombo_{};
+    QDoubleSpinBox* lineWidth_{};
+    QComboBox* markerCombo_{};
+    QDoubleSpinBox* markerSize_{};
+    ColorButton* markerColorBtn_{};
+    ColorButton* markerFaceBtn_{};
+    QCheckBox* visibleCheck_{};
 };
 
 /// @brief 曲面属性编辑页
@@ -88,18 +102,20 @@ class SurfacePropertyPage : public QWidget {
     Q_OBJECT
 public:
     explicit SurfacePropertyPage(QWidget* parent = nullptr);
+    SurfacePropertyPage(const SurfacePropertyPage&) = delete;
+    SurfacePropertyPage& operator=(const SurfacePropertyPage&) = delete;
     void load(matplot::surface* surf, int index);
     void apply(matplot::surface* surf);
 
 private:
     void setupUi();
-    QLineEdit* nameEdit_;
-    QCheckBox* surfaceVisible_;
-    QCheckBox* lightingCheck_;
-    QDoubleSpinBox* faceAlpha_;
-    ColorButton* edgeColorBtn_;
-    QDoubleSpinBox* edgeWidth_;
-    QCheckBox* colorbarVisible_;
+    QLineEdit* nameEdit_{};
+    QCheckBox* surfaceVisible_{};
+    QCheckBox* lightingCheck_{};
+    QDoubleSpinBox* faceAlpha_{};
+    ColorButton* edgeColorBtn_{};
+    QDoubleSpinBox* edgeWidth_{};
+    QCheckBox* colorbarVisible_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstChart/QWT/QwtBackend.cpp
+++ b/src/AstChart/QWT/QwtBackend.cpp
@@ -25,6 +25,7 @@
 #include "ColoredSurfacePlot.hpp"
 #include "UiFigure.hpp"
 
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/core/axes_type.h>
 #include <matplot/core/figure_type.h>
 #include <matplot/backend/backend_registry.h>
@@ -41,6 +42,7 @@
 #include <qwt3d_surfaceplot.h>
 
 #include <matplot/axes_objects/surface.h>
+A_SUPPRESS_WARNINGS_END
 
 #include <QApplication>
 #include <QEventLoop>

--- a/src/AstChart/QWT/QwtBackend.cpp
+++ b/src/AstChart/QWT/QwtBackend.cpp
@@ -65,12 +65,12 @@ public:
     static constexpr unsigned int kDefaultPosY = 558;
 public:
     matplot::figure_type* pltfigure_{nullptr};
-    QPointer<UiFigure> uifigure_;
+    QPointer<UiFigure> uifigure_{};
     unsigned int width_ {kDefaultWidth};
     unsigned int height_{kDefaultHeight};
     unsigned int pos_x_ {kDefaultPosX};
     unsigned int pos_y_ {kDefaultPosY};
-    std::string window_title_;
+    std::string window_title_{};
 public:
     UiFigure* getUiFigure();
     UiFigure* getUiFigure(matplot::figure_type* f);

--- a/src/AstChart/QWT/QwtBackend.hpp
+++ b/src/AstChart/QWT/QwtBackend.hpp
@@ -21,7 +21,9 @@
 #pragma once
 
 #include "AstGlobal.h"
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/backend/backend_interface.h>
+A_SUPPRESS_WARNINGS_END
 #include <memory>
 #include <string>
 

--- a/src/AstChart/QWT/QwtPlotVisitor.cpp
+++ b/src/AstChart/QWT/QwtPlotVisitor.cpp
@@ -22,6 +22,7 @@
 #include "ColoredSurfacePlot.hpp"
 #include "ColoredSurfaceEnrichment.hpp"
 
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/axes_objects/function_line.h>
 #include <matplot/axes_objects/histogram.h>
 #include <matplot/axes_objects/line.h>
@@ -29,6 +30,7 @@
 #include <matplot/axes_objects/surface.h>
 #include <matplot/core/line_spec.h>
 #include <matplot/core/axes_type.h>
+A_SUPPRESS_WARNINGS_END
 
 #include <qwt_plot.h>
 #include <qwt_plot_curve.h>

--- a/src/AstChart/QWT/QwtPlotVisitor.hpp
+++ b/src/AstChart/QWT/QwtPlotVisitor.hpp
@@ -45,6 +45,8 @@ public:
     explicit QwtPlotVisitor(QwtPlot* plot);
     explicit QwtPlotVisitor(ColoredSurfacePlot* surface);
     ~QwtPlotVisitor() override;
+    QwtPlotVisitor(const QwtPlotVisitor&) = delete;
+    QwtPlotVisitor& operator=(const QwtPlotVisitor&) = delete;
 
     void visit(matplot::line& l) override;
     void visit(matplot::histogram& h) override;

--- a/src/AstChart/QWT/QwtPlotVisitor.hpp
+++ b/src/AstChart/QWT/QwtPlotVisitor.hpp
@@ -21,7 +21,9 @@
 #pragma once
 
 #include "AstGlobal.h"
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/util/visitor.h>
+A_SUPPRESS_WARNINGS_END
 #include <array>
 #include <QColor>
 

--- a/src/AstChart/QWT/UiFigure.cpp
+++ b/src/AstChart/QWT/UiFigure.cpp
@@ -69,9 +69,11 @@ public:
     ~figure_silencer() {
         figure_->quiet_mode(previous_quiet_mode_);
     }
+    figure_silencer(const figure_silencer&) = delete;
+    figure_silencer& operator=(const figure_silencer&) = delete;
 private:
     figure_type *figure_;
-    bool previous_quiet_mode_;
+    bool previous_quiet_mode_{};
 };
 UiFigure::UiFigure(matplot::figure_type* pltfigure, QWidget* parent)
     : QWidget(parent)

--- a/src/AstChart/QWT/UiFigure.cpp
+++ b/src/AstChart/QWT/UiFigure.cpp
@@ -23,9 +23,11 @@
 #include "EditFigureOverlay.hpp"
 #include "EditFigureDialog.hpp"
 
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/core/axes_type.h>
 #include <matplot/core/figure_type.h>
 #include <matplot/freestanding/plot.h>
+A_SUPPRESS_WARNINGS_END
 
 #include <QVBoxLayout>
 #include <QToolBar>

--- a/src/AstChart/QWT/UiFigure.hpp
+++ b/src/AstChart/QWT/UiFigure.hpp
@@ -55,6 +55,8 @@ public:
     explicit UiFigure(matplot::figure_type* pltfigure, QWidget* parent = nullptr);
 
     ~UiFigure() override;
+    UiFigure(const UiFigure&) = delete;
+    UiFigure& operator=(const UiFigure&) = delete;
 
     /// @brief 获取内部的 QwtFigure
     QwtFigure* qwtfigure() const { return qwtfigure_; }

--- a/src/AstChart/QWT/UiFigure.hpp
+++ b/src/AstChart/QWT/UiFigure.hpp
@@ -153,19 +153,19 @@ private:
     QAction*                                pickNearestAction_ = nullptr;
     QMenu*                                  dataPickMenu_ = nullptr;
     QToolButton*                            dataPickBtn_ = nullptr;
-    QMap<QwtPlot*, AxisLimits>              originalLimits_;
-    QList<QPointer<QwtPlotPanner>>          panners_;
-    QList<QPointer<QwtPlotCanvasZoomer>>    zoomers_;
-    QList<QPointer<QwtPlotSeriesDataPicker>> dataPickers_;
-    QScopedPointer<QwtPlotSeriesDataPickerGroup> dataPickerGroup_;
+    QMap<QwtPlot*, AxisLimits>              originalLimits_{};
+    QList<QPointer<QwtPlotPanner>>          panners_{};
+    QList<QPointer<QwtPlotCanvasZoomer>>    zoomers_{};
+    QList<QPointer<QwtPlotSeriesDataPicker>> dataPickers_{};
+    QScopedPointer<QwtPlotSeriesDataPickerGroup> dataPickerGroup_{};
 
     // 编辑模式
     QAction*                                editModeAction_ = nullptr;
-    QScopedPointer<QwtFigureWidgetOverlay>  overlay_;
+    QScopedPointer<QwtFigureWidgetOverlay>  overlay_{};
 
     // 属性检查器
     QAction*                                propertiesAction_ = nullptr;
-    QPointer<EditFigureDialog>              propertiesDialog_;
+    QPointer<EditFigureDialog>              propertiesDialog_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstCmd/CommandDispatcher.hpp
+++ b/src/AstCmd/CommandDispatcher.hpp
@@ -46,7 +46,7 @@ public:
     void addRuleHandler(StringView tmpl, std::shared_ptr<CommandHandler> handler);
     CommandTrie::Node& addRule(StringView tmpl);
 private:
-    CommandTrie trie_;  ///< 命令路由树
+    CommandTrie trie_{}; ///< 命令路由树
 };
 
 

--- a/src/AstCmd/CommandRouting.hpp
+++ b/src/AstCmd/CommandRouting.hpp
@@ -67,7 +67,7 @@ public:
     CommandHandler* handler() { return handler_; }
     void setHandler(CommandHandler* handler) { handler_ = handler; }
 private:
-    CommandParams params_;              ///< 命令参数
+    CommandParams params_{};             ///< 命令参数
     CommandHandler* handler_{nullptr};  ///< 命令处理函数
 };
 
@@ -108,15 +108,15 @@ public:
         }
     public:
         int                             numParams_{-1};     ///< 该键值之后的参数数量， -1 表示未初始化
-        std::string                     key_;               ///< 键值
-        std::shared_ptr<CommandHandler> handler_;           ///< 命令处理函数
-        std::vector<Node>               children_;          ///< 子节点
+        std::string                     key_{};              ///< 键值
+        std::shared_ptr<CommandHandler> handler_{};          ///< 命令处理函数
+        std::vector<Node>               children_{};         ///< 子节点
     };
     Node& addRule(StringView tmpl);
     void addRule(StringView tmpl, std::shared_ptr<CommandHandler> handler);
     errc_t find(StringView text, RoutingHandleResult& result) const;
 private:
-    Node root_;
+    Node root_{};
 };
 
 

--- a/src/AstCmd/CommandUtil.hpp
+++ b/src/AstCmd/CommandUtil.hpp
@@ -65,7 +65,9 @@ constexpr bool is_type(const char* s, int p, const char* type) {
 // 辅助递归函数，比较类型字符串并检查终止字符
 constexpr bool is_type_impl(const char* s, int p, const char* type, int i) {
     return type[i] == '\0'
-               ? (s[p + i] == '>' || s[p + i] == ':')
+               // 使用 | 而不是 ||，使用 || 运算符在一些旧编译器中无法编译期求值，
+               // 可能因为 || 的短路求值特性，一些旧编译器实现存在缺陷
+               ? ((s[p + i] == '>') | (s[p + i] == ':'))
                : (s[p + i] == type[i] && is_type_impl(s, p, type, i + 1));
 }
 

--- a/src/AstCore/Atmosphere/AtmosphereBase.hpp
+++ b/src/AstCore/Atmosphere/AtmosphereBase.hpp
@@ -36,6 +36,9 @@ public:
     AtmosphereBase(Frame* frame, BodyShape* bodyShape);
     ~AtmosphereBase() override = default;
 
+    AtmosphereBase(const AtmosphereBase&) = delete;
+    AtmosphereBase& operator=(const AtmosphereBase&) = delete;
+
     /// @brief 获取大气密度
     /// @param tp 当前时间
     /// @param posInBodyFixed 当前位置(相对于getFrame()返回的坐标系)

--- a/src/AstCore/Atmosphere/HarrisPriester.hpp
+++ b/src/AstCore/Atmosphere/HarrisPriester.hpp
@@ -36,6 +36,9 @@ class AST_CORE_API HarrisPriester: public AtmosphereBase
 public:
     HarrisPriester(Frame* frame, BodyShape* bodyShape, CelestialBody* sun, double f107);
 
+    HarrisPriester(const HarrisPriester&) = delete;
+    HarrisPriester& operator=(const HarrisPriester&) = delete;
+
     double getDensity(const TimePoint& tp, const Vector3d& posInBodyFixed) const override;
 
     void setSunPosition(ESunPosition sunPosition){sunPosition_ = sunPosition;}

--- a/src/AstCore/Atmosphere/JacchiaRoberts.hpp
+++ b/src/AstCore/Atmosphere/JacchiaRoberts.hpp
@@ -37,7 +37,10 @@ class AST_CORE_API JacchiaRoberts final: public AtmosphereBase
 {
 public:
     JacchiaRoberts(Frame* frame, BodyShape* bodyShape, CelestialBody* sun, double f107Daily, double f107Average, double kp);
-    
+
+    JacchiaRoberts(const JacchiaRoberts&) = delete;
+    JacchiaRoberts& operator=(const JacchiaRoberts&) = delete;
+
     double getDensity(const TimePoint& tp, const Vector3d& posInBodyFixed) const override;
 
     void setSunPosition(ESunPosition sunPosition){sunPosition_ = sunPosition;}

--- a/src/AstCore/Atmosphere/MSISBase.hpp
+++ b/src/AstCore/Atmosphere/MSISBase.hpp
@@ -85,7 +85,7 @@ protected:
 protected:
     ScopedPtr<SpaceWeatherProvider> spaceWeather_;    ///< 空间天气数据源
 private:
-    mutable std::aligned_storage<57000>::type storage_;
+    mutable std::aligned_storage<57000>::type storage_{};
     bool useDailyAp_{false};                        ///< 是否使用每日Ap值，否则使用3小时Ap值
 };
 

--- a/src/AstCore/Coordinate/Axes/AxesBodyRelated.hpp
+++ b/src/AstCore/Coordinate/Axes/AxesBodyRelated.hpp
@@ -38,6 +38,9 @@ class AST_CORE_API AxesBodyRelated : public Axes
 public:
     explicit AxesBodyRelated(CelestialBody* body);
     ~AxesBodyRelated() override = default;
+
+    AxesBodyRelated(const AxesBodyRelated&) = delete;
+    AxesBodyRelated& operator=(const AxesBodyRelated&) = delete;
 protected:
     /// @brief 获取天体的姿态/指向
     BodyOrientation* getBodyOrientation() const;

--- a/src/AstCore/Coordinate/Axes/AxesFrozenAtEventTime.hpp
+++ b/src/AstCore/Coordinate/Axes/AxesFrozenAtEventTime.hpp
@@ -77,9 +77,9 @@ public:
     /// @brief 设置冻结时间点
     void setEpoch(const TimePoint& epoch);
 protected:
-    SharedPtr<Axes>         referenceAxes_;     ///< 参考轴系
-    SharedPtr<Axes>         axes_;              ///< 冻结轴系
-    SharedPtr<EventTime>    epoch_;             ///< 冻结时间
+    SharedPtr<Axes>         referenceAxes_{};    ///< 参考轴系
+    SharedPtr<Axes>         axes_{};             ///< 冻结轴系
+    SharedPtr<EventTime>    epoch_{};            ///< 冻结时间
 };
 
 /*! @} */

--- a/src/AstCore/Coordinate/Axes/AxesLinkTo.hpp
+++ b/src/AstCore/Coordinate/Axes/AxesLinkTo.hpp
@@ -49,7 +49,7 @@ public:
 public:
     Axes* resolve(Object* scope) const;
 private:
-    std::string objectType_;
+    std::string objectType_{};
 };
 
 /*! @} */

--- a/src/AstCore/Coordinate/Axes/BuiltinAxesRegistry.cpp
+++ b/src/AstCore/Coordinate/Axes/BuiltinAxesRegistry.cpp
@@ -32,6 +32,7 @@ BuiltinAxesRegistry &BuiltinAxesRegistry::Instance()
 }
 
 BuiltinAxesRegistry::BuiltinAxesRegistry(bool shouldInitialize)
+    : axesMap_()
 {
     if (shouldInitialize)
     {

--- a/src/AstCore/Coordinate/Frame/FrameAssembly.hpp
+++ b/src/AstCore/Coordinate/Frame/FrameAssembly.hpp
@@ -72,8 +72,8 @@ PROPERTIES:
     Axes* getAxes() const final { return axes_.get(); }
     void setAxes(Axes* axes) { axes_ = axes; }
 protected:
-    SharedPtr<Point> origin_;    ///< 原点
-    SharedPtr<Axes>  axes_;      ///< 轴系统
+    SharedPtr<Point> origin_{};   ///< 原点
+    SharedPtr<Axes>  axes_{};     ///< 轴系统
 };
 
 /*! @} */

--- a/src/AstCore/Coordinate/Frame/FrameWithEpoch.cpp
+++ b/src/AstCore/Coordinate/Frame/FrameWithEpoch.cpp
@@ -45,7 +45,7 @@ HFrameWithEpoch FrameWithEpoch::MakeShared(Point *origin, Axes *axes, EventTime 
 }
 
 FrameWithEpoch::FrameWithEpoch()
-    : frozenAxes_{new AxesFrozenAtEventTime()}
+    : origin_(), frozenAxes_{new AxesFrozenAtEventTime()}, sourceAxes_()
 {
 }
 

--- a/src/AstCore/Coordinate/IERS/IAUXYS.hpp
+++ b/src/AstCore/Coordinate/IERS/IAUXYS.hpp
@@ -56,9 +56,9 @@ public:
     bool isLoaded() const {return isLoaded_;}
     
 protected:
-    NutationSeries xSeries_;        ///< 岁差章动模型X系数
-    NutationSeries ySeries_;        ///< 岁差章动模型Y系数
-    NutationSeries spxy2Series_;    ///< 岁差章动模型S+XY/2
+    NutationSeries xSeries_{};        ///< 岁差章动模型X系数
+    NutationSeries ySeries_{};        ///< 岁差章动模型Y系数
+    NutationSeries spxy2Series_{};   ///< 岁差章动模型S+XY/2
     bool isLoaded_ {false};         ///< 检查是否加载了系数表
 };
 

--- a/src/AstCore/Coordinate/IERS/IAUXYSPrecomputed.cpp
+++ b/src/AstCore/Coordinate/IERS/IAUXYSPrecomputed.cpp
@@ -30,6 +30,7 @@
 AST_NAMESPACE_BEGIN
 
 IAUXYSPrecomputed::IAUXYSPrecomputed()
+    : xys_points_(), denom_array_(), time_array_()
 {
     
 }

--- a/src/AstCore/Coordinate/IERS/NutationSeries.hpp
+++ b/src/AstCore/Coordinate/IERS/NutationSeries.hpp
@@ -73,9 +73,9 @@ protected:
     errc_t loadIERS(BKVParser& parser);
 
 protected:
-    Polynomial polynomial_;             ///< nutation series多项式
-    std::vector<NutationTerm> terms_;   ///< nutation series系数表
-    std::vector<int> jlist_;            ///< 
+    Polynomial polynomial_{};             ///< nutation series多项式
+    std::vector<NutationTerm> terms_{};   ///< nutation series系数表
+    std::vector<int> jlist_{};            ///< 
 };
 
 

--- a/src/AstCore/Coordinate/Point/PointBodyCenter.hpp
+++ b/src/AstCore/Coordinate/Point/PointBodyCenter.hpp
@@ -37,6 +37,10 @@ class AST_CORE_API PointBodyCenter final: public Point
 {
 public:
     PointBodyCenter() = default;
+
+    PointBodyCenter(const PointBodyCenter&) = delete;
+    PointBodyCenter& operator=(const PointBodyCenter&) = delete;
+
     explicit PointBodyCenter(CelestialBody* body);
     ~PointBodyCenter() = default;
     CelestialBody* getBody() const{ return body_; }

--- a/src/AstCore/Data/Context/DataContext.hpp
+++ b/src/AstCore/Data/Context/DataContext.hpp
@@ -99,14 +99,14 @@ public:
 	bool isInitialized() const {return !dataDir_.empty();}
 protected:
 	SharedPtr<SolarSystem>  solarSystem_{new SolarSystem("SolarSystem")};	///< 太阳系数据
-	EOP		    			eop_;											///< 地球指向数据
-	LeapSecond  			leapSecond_;									///< 闰秒数据
+	EOP		    			eop_{};											///< 地球指向数据
+	LeapSecond  			leapSecond_{};									///< 闰秒数据
 	// SpaceWeather          spaceWeather_;									///< 空间天气数据
-    JplDe                   jplDe_;											///< JPL DE星历数据
-	IAUXYSPrecomputed       iauXYSPrecomputed_;						///< IAU XYS预计算数据 @todo: 这个考虑更改为静态数据
-    std::string     		dataDir_;										///< 数据目录
+    JplDe                   jplDe_{};											///< JPL DE星历数据
+	IAUXYSPrecomputed       iauXYSPrecomputed_{};								///< IAU XYS预计算数据 @todo: 这个考虑更改为静态数据
+    std::string     		dataDir_{};										///< 数据目录
 	TimePoint				epoch_{};										///< 参考历元
-	StartupConfig           config_;										///< 配置
+	StartupConfig           config_{};										///< 配置
 };
 
 constexpr size_t kSizeOfDataContext = sizeof(DataContext);

--- a/src/AstCore/Data/Context/GlobalContext.hpp
+++ b/src/AstCore/Data/Context/GlobalContext.hpp
@@ -42,7 +42,7 @@ public:
 	const IAUXYS* iauXYS() const {return &iauXYS_;}
     IAUXYS* iauXYS() {return &iauXYS_;}
 protected:
-	IAUXYS                  iauXYS_;				///< IAU XYS数据 @todo: 这个考虑更改为静态数据
+	IAUXYS                  iauXYS_{};				///< IAU XYS数据 @todo: 这个考虑更改为静态数据
 };
 
 /*! @} */

--- a/src/AstCore/Data/Context/RunTime.hpp
+++ b/src/AstCore/Data/Context/RunTime.hpp
@@ -56,17 +56,17 @@ using StringVector = std::vector<std::string>;
 /// @brief 初始化配置
 struct InitalizeConfig
 {
-    std::string dataDir_;                  ///< 数据目录路径
-    std::string leapSecondFile_;           ///< 跳秒文件路径
-    std::string jplDeFile_;                ///< JPL DE文件路径
-    std::string eopFile_;                  ///< EOP文件路径
-    std::string spaceWeatherFile_;         ///< 空间天气文件路径
-    std::string iauxFile_;                 ///< IAU-X系数文件路径
-    std::string iauyFile_;                 ///< IAU-Y系数文件路径
-    std::string iausFile_;                 ///< IAU-Z系数文件路径
-    std::string iauXYSPrecomputedFile_;    ///< IAU-XYS预计算数据文件路径
-    std::string solarSystemDir_;           ///< 太阳系目录路径
-    StringVector spkFiles_;                ///< SPK文件路径列表
+    std::string dataDir_{};                 ///< 数据目录路径
+    std::string leapSecondFile_{};          ///< 跳秒文件路径
+    std::string jplDeFile_{};                ///< JPL DE文件路径
+    std::string eopFile_{};                  ///< EOP文件路径
+    std::string spaceWeatherFile_{};         ///< 空间天气文件路径
+    std::string iauxFile_{};                 ///< IAU-X系数文件路径
+    std::string iauyFile_{};                 ///< IAU-Y系数文件路径
+    std::string iausFile_{};                 ///< IAU-Z系数文件路径
+    std::string iauXYSPrecomputedFile_{};    ///< IAU-XYS预计算数据文件路径
+    std::string solarSystemDir_{};           ///< 太阳系目录路径
+    StringVector spkFiles_{};                ///< SPK文件路径列表
 };
 
 /// @brief 获取初始化配置

--- a/src/AstCore/Data/EOP.hpp
+++ b/src/AstCore/Data/EOP.hpp
@@ -210,7 +210,7 @@ protected:
     /// @param frac 插值系数
     void findEntryIndex(double mjdUTC, int& index, double& frac) const;
 protected:
-    std::vector<Entry> data_;
+    std::vector<Entry> data_{};
     int startMJD_ = 0;
     int endMJD_ = 0;
 };

--- a/src/AstCore/Data/Ephemeris/STKEphemerisFileParser.cpp
+++ b/src/AstCore/Data/Ephemeris/STKEphemerisFileParser.cpp
@@ -90,17 +90,17 @@ errc_t aLoadSTKEphemeris(BKVParser &parser, ScopedPtr<Ephemeris> &ephemeris)
     BKVParser::EToken token;
     BKVItemView item;
     struct {
-        std::string binaryFileName_;                           ///< 二进制文件名称
+        std::string binaryFileName_{};                           ///< 二进制文件名称
         int numberOfEphemerisPoints_{0};                       ///< 星历点数
         TimePoint scenarioEpoch_{};                            ///< 场景时间点
         EInterpolationMethod interpolationMethod_{eUnknown};   ///< 插值方法
         int interpolationSamplesM1_{5};                        ///< 插值样本数减1(Minus 1)，相当于插值阶数
         double distanceUnitFactor_{1.0};                       ///< 距离单位的因子
-        HBody body_;                                           ///< 天体
-        HFrame frame_;                                         ///< 坐标系
-        std::vector<Vector3d> positions_;                      ///< 位置序列
-        std::vector<Vector3d> velocities_;                     ///< 速度序列
-        std::vector<double>   times_;                          ///< 时间序列
+        HBody body_{};                                          ///< 天体
+        HFrame frame_{};                                        ///< 坐标系
+        std::vector<Vector3d> positions_{};                     ///< 位置序列
+        std::vector<Vector3d> velocities_{};                    ///< 速度序列
+        std::vector<double>   times_{};                         ///< 时间序列
     } data;
     
     // 解析文件头部

--- a/src/AstCore/Data/JplDe.cpp
+++ b/src/AstCore/Data/JplDe.cpp
@@ -192,6 +192,7 @@ JplDe::JplDe()
     , ephemEnd_(0)
     , deFile_(nullptr)
     , dataBlocks_ (nullptr)
+    , dataBlockMutex_()
 {
 
 }

--- a/src/AstCore/Data/JplDe.hpp
+++ b/src/AstCore/Data/JplDe.hpp
@@ -61,6 +61,9 @@ public:
     JplDe();
     ~JplDe();
 
+    JplDe(const JplDe&) = delete;
+    JplDe& operator=(const JplDe&) = delete;
+
     /// @brief  打开JPL DE文件
     /// @param  filepath - JPL DE文件路径
     /// @retval          - 错误码

--- a/src/AstCore/Data/JplSpk.hpp
+++ b/src/AstCore/Data/JplSpk.hpp
@@ -104,7 +104,7 @@ public:
         std::vector<int>& ids
     ) const;
 protected:
-    std::string spkfile_;                   ///< SPK文件路径
+    std::string spkfile_{};                  ///< SPK文件路径
     int handle_{0};                         ///< 库句柄
     mutable bool isIntervalCached_{false};  ///< 是否缓存了时间间隔
     mutable TimeInterval intervalCache_{};  ///< 时间间隔缓存

--- a/src/AstCore/Data/LeapSecond.hpp
+++ b/src/AstCore/Data/LeapSecond.hpp
@@ -129,7 +129,7 @@ public:
 
 
 protected:
-    std::vector<Entry> data_;
+    std::vector<Entry> data_{};
 };
 
 

--- a/src/AstCore/Data/SpaceWeather.hpp
+++ b/src/AstCore/Data/SpaceWeather.hpp
@@ -148,7 +148,7 @@ protected:
     void findFluxIndex(double mjdUTC, int& index, double& frac) const;
 
 protected:
-    std::vector<Entry> data_;
+    std::vector<Entry> data_{};
     int startMJD_ = 0;
     int endMJD_ = 0;
 };

--- a/src/AstCore/Data/SpiceAPI.cpp
+++ b/src/AstCore/Data/SpiceAPI.cpp
@@ -151,6 +151,7 @@ SpiceAPI* SpiceAPI::Instance()
 }
 
 SpiceAPI::SpiceAPI(bool shouldLoadDynamicLib)
+    : spk_handles_(), mutex_()
 {
     if(shouldLoadDynamicLib)
     {

--- a/src/AstCore/ForceModel/Gravity/GravityCalculator.hpp
+++ b/src/AstCore/ForceModel/Gravity/GravityCalculator.hpp
@@ -183,25 +183,25 @@ private:
 
 private:
     /// @brief 递归系数 g_{n,m}/√j
-    std::vector<double> gnmOj_;
-    
+    std::vector<double> gnmOj_{};
+
     /// @brief 递归系数 h_{n,m}/√j
-    std::vector<double> hnmOj_;
-    
+    std::vector<double> hnmOj_{};
+
     /// @brief 递归系数 e_{n,m}
-    std::vector<double> enm_;
-    
+    std::vector<double> enm_{};
+
     /// @brief 缩放扇区项 Pbar_{m,m}/u^m × 2^{-SCALING}
-    std::vector<double> sectorial_;
+    std::vector<double> sectorial_{};
 private:
-    std::vector<double> pnm0Plus2;
-    std::vector<double> pnm0Plus1;
-    std::vector<double> pnm0;
-    std::vector<double> pnm1;
+    std::vector<double> pnm0Plus2{};
+    std::vector<double> pnm0Plus1{};
+    std::vector<double> pnm0{};
+    std::vector<double> pnm1{};
 private:
-    std::vector<double> aOrN;
-    std::vector<double> cosLambdaN;
-    std::vector<double> sinLambdaN;
+    std::vector<double> aOrN{};
+    std::vector<double> cosLambdaN{};
+    std::vector<double> sinLambdaN{};
 };
 
 

--- a/src/AstCore/ForceModel/Gravity/GravityCalculator.hpp
+++ b/src/AstCore/ForceModel/Gravity/GravityCalculator.hpp
@@ -214,6 +214,9 @@ public:
     GravityCalculator3(const GravityField &gravityField, int degree, int order);
     GravityCalculator3(GravityField &&gravityField, int degree, int order);
 
+    GravityCalculator3(const GravityCalculator3&) = delete;
+    GravityCalculator3& operator=(const GravityCalculator3&) = delete;
+
     ~GravityCalculator3() override;
     
     void calcPertAcceleration(const Vector3d &positionCBF, Vector3d &accelerationCBF) final;

--- a/src/AstCore/ForceModel/Gravity/GravityField.hpp
+++ b/src/AstCore/ForceModel/Gravity/GravityField.hpp
@@ -55,9 +55,9 @@ public:
 protected:
     int maxDegree_{0};                      ///< 最大阶数
     int maxOrder_{0};                       ///< 最大次数
-    std::string centralBody_;               ///< 中心天体名称
-    std::string model_;                     ///< 重力场模型名称
-    std::string referenceFrame_;            ///< 重力场的参考系名称：例如月球的重力场参考系 PrincipalAxes_421、PrincipalAxes_403等，默认为天体固连系
+    std::string centralBody_{};              ///< 中心天体名称
+    std::string model_{};                    ///< 重力场模型名称
+    std::string referenceFrame_{};           ///< 重力场的参考系名称：例如月球的重力场参考系 PrincipalAxes_421、PrincipalAxes_403等，默认为天体固连系
     double gm_{0};                          ///< 中心天体引力常数
     double refDistance_{0};                 ///< 参考距离
     bool normalized_{false};                ///< 是否归一化
@@ -79,7 +79,7 @@ public:
 public:
     bool normalized_{false};                 ///< 该系数是否是归一化系数
     TimePoint referenceEpoch_{};             ///< 参考时间点
-    std::vector<Variation> variations_;      ///< 长期变化系数列表
+    std::vector<Variation> variations_{};     ///< 长期变化系数列表
 };
 
 /// @brief 重力场系数
@@ -221,9 +221,9 @@ public:
     /// @brief 初始化系数矩阵
     void initCoeffMatrices();
 protected:
-    LowerMatrixd sinCoeff_;                 ///< Snm系数
-    LowerMatrixd cosCoeff_;                 ///< Cnm系数
-    SecularVariations secularVariations_;   ///< 重力场长期变化
+    LowerMatrixd sinCoeff_{};                ///< Snm系数
+    LowerMatrixd cosCoeff_{};                ///< Cnm系数
+    SecularVariations secularVariations_{};  ///< 重力场长期变化
 };
 
 inline double &GravityField::snm(int n, int m)

--- a/src/AstCore/ForceModel/Gravity/GravityFieldLoader.hpp
+++ b/src/AstCore/ForceModel/Gravity/GravityFieldLoader.hpp
@@ -45,6 +45,10 @@ public:
     explicit GravityFieldLoader(StringView dirpath)
         : dirpath_(dirpath)
     {}
+
+    GravityFieldLoader(const GravityFieldLoader&) = delete;
+    GravityFieldLoader& operator=(const GravityFieldLoader&) = delete;
+
     GravityFieldLoader(int maxLoadDegree, int maxLoadOrder, StringView dirpath)
         : dirpath_(dirpath), maxLoadDegree_(maxLoadDegree), maxLoadOrder_(maxLoadOrder)
     {}
@@ -69,10 +73,10 @@ public:
     void setMaxLoadOrder(int maxLoadOrder) { maxLoadOrder_ = maxLoadOrder; }
 
 public:    
-    BKVParser parser_;                      ///< 解析器
+    BKVParser parser_{};                     ///< 解析器
     GravityFieldHead* head_{nullptr};       ///< 重力场头
     GravityField* coeff_{nullptr};          ///< 重力场系数
-    StringView dirpath_;                    ///< 重力场模型文件所在目录路径
+    StringView dirpath_{};                    ///< 重力场模型文件所在目录路径
     int maxLoadDegree_ {-1};                ///< 最大加载阶数
     int maxLoadOrder_ {-1};                 ///< 最大加载次数
 };

--- a/src/AstCore/ForceModel/HPOPForceModel.hpp
+++ b/src/AstCore/ForceModel/HPOPForceModel.hpp
@@ -141,11 +141,11 @@ private:
     bool                        useSTM_{false};                     ///< 是否使用状态转换矩阵
     bool                        useDragSensitivity_{false};         ///< 是否启用弹道系数B敏感度预报
     bool                        useSRPSensitivity_{false};          ///< 是否启用SRP综合参数K敏感度预报
-    SharedPtr<Body>             centralBody_;                       ///< 中心天体(定义引力场模型所属天体，以及进行轨道预报的坐标系)
-    DragForce                   drag_;                              ///< 大气阻力
-    SolarRadiationPressure      srp_;                               ///< 太阳辐射压模型
-    ThirdBodyList               thirdBodies_;                       ///< 三体引力 
-    ClonePtr<BodyAttraction>    bodyAttraction_;                    ///< 中心天体引力模型(二体或者引力场)
+    SharedPtr<Body>             centralBody_{};                      ///< 中心天体(定义引力场模型所属天体，以及进行轨道预报的坐标系)
+    DragForce                   drag_{};                             ///< 大气阻力
+    SolarRadiationPressure      srp_{};                              ///< 太阳辐射压模型
+    ThirdBodyList               thirdBodies_{};                      ///< 三体引力
+    ClonePtr<BodyAttraction>    bodyAttraction_{};                   ///< 中心天体引力模型(二体或者引力场)
 
     bool useMoonGravity_{false};
     double moonGravity_{kMoonGrav};

--- a/src/AstCore/ForceModel/SolarRadiationPressure.hpp
+++ b/src/AstCore/ForceModel/SolarRadiationPressure.hpp
@@ -51,7 +51,7 @@ public:
     ESunPosition sunPosition_{ESunPosition::eTrue};      ///< 太阳位置
     bool detectShadowBoundaries_{false};                 ///< 是否检测阴影边界[暂不支持该参数]
     EShadowModel shadowModel_{EShadowModel::eDualCone};  ///< 阴影模型类型
-    std::vector<HCelestialBody> eclipsingBodies_;        ///< 遮挡天体列表
+    std::vector<HCelestialBody> eclipsingBodies_{};        ///< 遮挡天体列表
     double atmAltForEclipse_{0.0};                       ///< 用于计算阴影边界的大气高度[暂不支持该参数]
 };
 

--- a/src/AstCore/ForceModel/ThirdBodyForce.hpp
+++ b/src/AstCore/ForceModel/ThirdBodyForce.hpp
@@ -86,7 +86,7 @@ public:
     /// @brief 设置星历来源
     void setEphemerisSource(EEphemerisSource source){ephemerisSource_ = source;}
 private:
-    HCelestialBody body_;                                                       ///< 天体
+    HCelestialBody body_{};                                                       ///< 天体
     EEphemerisSource ephemerisSource_{EEphemerisSource::eBodyEphemeris};        ///< 星历来源
     EBodyAttractionType attractionType_{EBodyAttractionType::ePointMass};       ///< 引力类型
     PointMassForce pointMass_{};                                                ///< 点质量引力模型

--- a/src/AstCore/Geometry/Eclipse/EclipseCalculator.hpp
+++ b/src/AstCore/Geometry/Eclipse/EclipseCalculator.hpp
@@ -63,7 +63,7 @@ public:
     void addOccultingBody(HCelestialBody occultingBody) {occultingBodies_.push_back(occultingBody);}
 protected:
     HCelestialBody lightSource_{nullptr};           ///< 光源体
-    std::vector<HCelestialBody> occultingBodies_;   ///< 阴影体列表
+    std::vector<HCelestialBody> occultingBodies_{};   ///< 阴影体列表
 };
 
 

--- a/src/AstCore/Geometry/FieldOfView/FOVCustom.hpp
+++ b/src/AstCore/Geometry/FieldOfView/FOVCustom.hpp
@@ -52,7 +52,7 @@ public:
     const std::vector<Vector3d>& getVertices() const { return vertices_; }
     
 private:
-    std::vector<Vector3d> vertices_;  ///< 自定义视场的顶点列表
+    std::vector<Vector3d> vertices_{};  ///< 自定义视场的顶点列表
 };
 
 AST_NAMESPACE_END

--- a/src/AstCore/Orbit/Burn/BurnImpulsive.hpp
+++ b/src/AstCore/Orbit/Burn/BurnImpulsive.hpp
@@ -61,8 +61,8 @@ public:
     const Vector3d& impulse() const {return impulse_;}
     void setImpulse(const Vector3d& value) {impulse_ = value;}
 private:
-    WeakPtr<Axes> axes_;
-    Vector3d impulse_;
+    WeakPtr<Axes> axes_{};
+    Vector3d impulse_{};
 };
 
 

--- a/src/AstCore/Orbit/Calculation/ScStateCalculation/Abstract/ScStateCalcBodyRelated.hpp
+++ b/src/AstCore/Orbit/Calculation/ScStateCalculation/Abstract/ScStateCalcBodyRelated.hpp
@@ -43,7 +43,7 @@ PROPERTIES:
     Body* body() const { return body_.get(); }
     void setBody(Body* body) { body_ = body; }
 private:
-    WeakPtr<CelestialBody> body_;
+    WeakPtr<CelestialBody> body_{};
 };
 
 /*! @} */

--- a/src/AstCore/Orbit/Calculation/ScStateCalculation/Abstract/ScStateCalcFrameRelated.hpp
+++ b/src/AstCore/Orbit/Calculation/ScStateCalculation/Abstract/ScStateCalcFrameRelated.hpp
@@ -44,7 +44,7 @@ PROPERTIES:
     Frame* frame() const { return frame_.get(); }
     void setFrame(Frame* frame) { frame_ = frame; }
 private:
-    WeakPtr<Frame> frame_;
+    WeakPtr<Frame> frame_{};
 };
 
 /*! @} */

--- a/src/AstCore/Orbit/Calculation/ScStateCalculation/Others/ScStateCalcDifference.hpp
+++ b/src/AstCore/Orbit/Calculation/ScStateCalculation/Others/ScStateCalcDifference.hpp
@@ -55,8 +55,8 @@ public:
 protected:
     Segment* getSegment();
 private:
-    WeakPtr<Segment> segment_;
-    WeakPtr<ScStateCalculation> calculation_;
+    WeakPtr<Segment> segment_{};
+    WeakPtr<ScStateCalculation> calculation_{};
     EDifferenceOrderToUse differenceOrderToUse_{EDifferenceOrderToUse::eCurrentMinusInitial};
 };
 

--- a/src/AstCore/Orbit/Calculation/ScStateCalculation/Others/ScStateCalcPointRelated.hpp
+++ b/src/AstCore/Orbit/Calculation/ScStateCalculation/Others/ScStateCalcPointRelated.hpp
@@ -41,7 +41,7 @@ PROPERTIES:
     Point* point() const { return point_.get(); }
     void setPoint(Point* point) { point_ = point; }
 private:
-    WeakPtr<Point> point_;      ///< 点
+    WeakPtr<Point> point_{};      ///< 点
 };
 
 /*! @} */

--- a/src/AstCore/Orbit/Calculation/ScStateCalculation/Scripts/ScStateCalcScript.hpp
+++ b/src/AstCore/Orbit/Calculation/ScStateCalculation/Scripts/ScStateCalcScript.hpp
@@ -49,8 +49,8 @@ protected:
     /// @brief 创建脚本执行器
     virtual ScriptExecutor* newScriptExecutor() const = 0;
 private:
-    std::string expression_;     ///< 脚本表达式
-    VariableList variables_;     ///< 脚本变量列表
+    std::string expression_{};     ///< 脚本表达式
+    VariableList variables_{};     ///< 脚本变量列表
 };
 
 

--- a/src/AstCore/Orbit/Ephemeris/EphemerisBinary.hpp
+++ b/src/AstCore/Orbit/Ephemeris/EphemerisBinary.hpp
@@ -97,16 +97,16 @@ private:
     Interval            interval_{};              ///< 星历时间范围，相对于历元时间
     double              averageStep_{60.0};       ///< 平均时间步长，用于估算索引
     size_t              pointCount_{0};           ///< 总星历点数
-    std::string         filepath_;                ///< 二进制文件路径
-    std::string         frameName_;               ///< 坐标系名称
-    mutable SharedPtr<Frame> frame_;              ///< 解析后的坐标系指针
+    std::string         filepath_{};               ///< 二进制文件路径
+    std::string         frameName_{};              ///< 坐标系名称
+    mutable SharedPtr<Frame> frame_{};             ///< 解析后的坐标系指针
 
     // 固定窗口缓存
     static constexpr size_t HEADER_BASE = 56;    // 基础头大小 (不含变长帧名)
     static constexpr size_t POINT_BYTES = 56;    // 7 doubles per point
-    mutable std::vector<double>   winTimes_;     ///< 窗口内的时间 (秒, 相对历元)
-    mutable std::vector<Vector3d> winPos_;       ///< 窗口内的位置
-    mutable std::vector<Vector3d> winVel_;       ///< 窗口内的速度
+    mutable std::vector<double>   winTimes_{};    ///< 窗口内的时间 (秒, 相对历元)
+    mutable std::vector<Vector3d> winPos_{};      ///< 窗口内的位置
+    mutable std::vector<Vector3d> winVel_{};      ///< 窗口内的速度
     mutable size_t winStart_{0};                  ///< 窗口在文件中的起始索引
 };
 

--- a/src/AstCore/Orbit/Ephemeris/EphemerisLagrangeVar.hpp
+++ b/src/AstCore/Orbit/Ephemeris/EphemerisLagrangeVar.hpp
@@ -67,9 +67,9 @@ private:
     int findIndex(double delta) const;
 protected:
     SharedPtr<Frame>      frame_;                   ///< 参考坐标系
-    std::vector<double>   times_;                   ///< 时间(单位：秒)
-    std::vector<Vector3d> positions_;               ///< 位置(单位：米)
-    std::vector<Vector3d> velocities_;              ///< 速度(单位：米/秒)
+    std::vector<double>   times_{};                  ///< 时间(单位：秒)
+    std::vector<Vector3d> positions_{};              ///< 位置(单位：米)
+    std::vector<Vector3d> velocities_{};             ///< 速度(单位：米/秒)
     TimePoint             epoch_{};                 ///< 历元时间
     double                averageStep_{60};         ///< 平均时间步长，用于估计插值开始的时间
     int                   interpolateOrder_{5};     ///< 插值阶数

--- a/src/AstCore/Orbit/Ephemeris/EphemerisLagrangeVar.hpp
+++ b/src/AstCore/Orbit/Ephemeris/EphemerisLagrangeVar.hpp
@@ -66,7 +66,7 @@ public:
 private:
     int findIndex(double delta) const;
 protected:
-    SharedPtr<Frame>      frame_;                   ///< 参考坐标系
+    SharedPtr<Frame>      frame_{};                  ///< 参考坐标系
     std::vector<double>   times_{};                  ///< 时间(单位：秒)
     std::vector<Vector3d> positions_{};              ///< 位置(单位：米)
     std::vector<Vector3d> velocities_{};             ///< 速度(单位：米/秒)

--- a/src/AstCore/Orbit/Mission/LandingSite.hpp
+++ b/src/AstCore/Orbit/Mission/LandingSite.hpp
@@ -59,7 +59,7 @@ public: /* 配置属性 */
     void setEpoch(const TimePoint& epoch) { epoch_ = epoch; }
 private:
     TimePoint     epoch_{};        ///< 着陆时间
-    WeakPtr<Body> body_;           ///< 着陆天体
+    WeakPtr<Body> body_{};          ///< 着陆天体
     GeodeticPoint position_{};     ///< 着陆点位置
 };
 

--- a/src/AstCore/Orbit/Mission/Maneuver.hpp
+++ b/src/AstCore/Orbit/Mission/Maneuver.hpp
@@ -49,7 +49,7 @@ PROPERTIES:
     Burn* burn() const {return burn_.get();}
     void setBurn(Burn* burn);
 private:
-    WeakPtr<Burn> burn_;        ///< 发动机点火
+    WeakPtr<Burn> burn_{};       ///< 发动机点火
 };
 
 

--- a/src/AstCore/Orbit/Mission/Profile/DifferentialCorrectorProfile.hpp
+++ b/src/AstCore/Orbit/Mission/Profile/DifferentialCorrectorProfile.hpp
@@ -152,7 +152,7 @@ public:
     ShooterResult* getResult(StringView name) const;
     ShooterControl* getControl(StringView name) const;
 private:
-    mutable WeakPtr<Command> relatedCommand_;
+    mutable WeakPtr<Command> relatedCommand_{};
 
     EConvergenceCriteria convergenceCriteria_{EConvergenceCriteria::eEqualityConstraintsWithinTolerance};
     EFiniteDifferenceMethod finiteDifferenceMethod_{EFiniteDifferenceMethod::eForwardDifference};
@@ -169,10 +169,10 @@ private:
     bool useHomotopy_ = false;
     bool useLineSearch_ = false;
 
-    ControlVector controls_;
-    ResultVector results_;
-    TargeterGraphVector graphs_;
-    SharedPtr<ScriptingToolProfile> scriptingTool_;
+    ControlVector controls_{};
+    ResultVector results_{};
+    TargeterGraphVector graphs_{};
+    SharedPtr<ScriptingToolProfile> scriptingTool_{};
 };
 
 /*! @} */

--- a/src/AstCore/Orbit/Mission/Profile/ScriptingToolProfile.hpp
+++ b/src/AstCore/Orbit/Mission/Profile/ScriptingToolProfile.hpp
@@ -72,10 +72,10 @@ public:
 
 private:
     EScriptLanguage language_{EScriptLanguage::ePython};    ///< 脚本语言
-    std::string scriptStatements_;                          ///< 脚本语句
-    VariableList attributes_;                               ///< 属性变量列表
-    VariableList parameters_;                               ///< 参数变量列表
-    VariableList calcObjects_;                              ///< 计算对象变量列表
+    std::string scriptStatements_{};                          ///< 脚本语句
+    VariableList attributes_{};                              ///< 属性变量列表
+    VariableList parameters_{};                              ///< 参数变量列表
+    VariableList calcObjects_{};                             ///< 计算对象变量列表
 };
 
 /*! @} */

--- a/src/AstCore/Orbit/Mission/Profile/ShooterControl.hpp
+++ b/src/AstCore/Orbit/Mission/Profile/ShooterControl.hpp
@@ -78,7 +78,7 @@ public:
     errc_t getValue(double& value) const;
 private:
     bool active_{true};             ///< 是否激活
-    WeakPtr<Expr> expr_;            ///< 表达式
+    WeakPtr<Expr> expr_{};            ///< 表达式
     double correction_{0.0};        ///< 修正值
     double maxStep_{100.0};         ///< 最大步长
     double perturbation_{0.1};      ///< 扰动值

--- a/src/AstCore/Orbit/Mission/Profile/ShooterResult.hpp
+++ b/src/AstCore/Orbit/Mission/Profile/ShooterResult.hpp
@@ -72,7 +72,7 @@ PROPERTIES:
 private:
     bool active_{false};        ///< 是否激活
     bool valid_{true};          ///< 数值是否有效
-    WeakPtr<Expr> expr_;        ///< 计算表达式
+    WeakPtr<Expr> expr_{};        ///< 计算表达式
     double desired_{0.0};       ///< 目标值
     double scale_{1.0};         ///< 缩放因子
     double tolerance_{0.0};     ///< 容差

--- a/src/AstCore/Orbit/Mission/Profile/VariableList.hpp
+++ b/src/AstCore/Orbit/Mission/Profile/VariableList.hpp
@@ -61,7 +61,7 @@ public:
     const_iterator end() const { return variables_.end(); }
 
 private:
-    ListType variables_;        ///< 变量列表
+    ListType variables_{};        ///< 变量列表
 };
 
 

--- a/src/AstCore/Orbit/Mission/Propagate.hpp
+++ b/src/AstCore/Orbit/Mission/Propagate.hpp
@@ -82,8 +82,8 @@ PROPERTIES:
     bool overrideMaxPropTime() const { return overrideMaxPropTime_; }
     void setOverrideMaxPropTime(bool overrideMaxPropTime) { overrideMaxPropTime_ = overrideMaxPropTime; }
 private:
-    WeakPtr<HPOP> propagator_;                                    ///< 轨道预报器
-    std::vector<SharedPtr<EventDetector>> eventDetectors_;        ///< 事件检测器
+    WeakPtr<HPOP> propagator_{};                                    ///< 轨道预报器
+    std::vector<SharedPtr<EventDetector>> eventDetectors_{};        ///< 事件检测器
     double minPropTime_{0};                                       ///< 最小预报时间??
     double maxPropTime_{8640000};                                 ///< 最大预报时间
     bool useMaxPropTime_{true};                                   ///< 是否使用最大预报时间

--- a/src/AstCore/Orbit/Mission/SegmentGraph.hpp
+++ b/src/AstCore/Orbit/Mission/SegmentGraph.hpp
@@ -43,7 +43,7 @@ public:
 public:
     errc_t execute() override;
 public:
-    std::vector<HMissionCommand> commands_;     ///< 任务命令序列
+    std::vector<HMissionCommand> commands_{};     ///< 任务命令序列
 };
 
 

--- a/src/AstCore/Orbit/Mission/Sequence.hpp
+++ b/src/AstCore/Orbit/Mission/Sequence.hpp
@@ -94,8 +94,8 @@ protected:
     void linkCommands();
 private:
     int repeatCount_{1};                                    ///< 重复次数
-    std::vector<HMissionCommand> commands_;                 ///< 任务命令序列
-    SharedPtr<ScriptingToolProfile> scriptingTool_;         ///< 脚本工具
+    std::vector<HMissionCommand> commands_{};                 ///< 任务命令序列
+    SharedPtr<ScriptingToolProfile> scriptingTool_{};         ///< 脚本工具
 };
 
 

--- a/src/AstCore/Orbit/Mission/TargeterSequence.hpp
+++ b/src/AstCore/Orbit/Mission/TargeterSequence.hpp
@@ -51,7 +51,7 @@ public:
     errc_t execute() override;
 
 private:
-    std::vector<HTargeterProfile> profiles_;
+    std::vector<HTargeterProfile> profiles_{};
 };
 
 

--- a/src/AstCore/Orbit/OrbitDesign/BaseOrbitDesigner.hpp
+++ b/src/AstCore/Orbit/OrbitDesign/BaseOrbitDesigner.hpp
@@ -40,7 +40,7 @@ class AST_CORE_API IOrbitDesigner
 {
 public:
     IOrbitDesigner() = default;
-    ~IOrbitDesigner() = default;
+    virtual ~IOrbitDesigner() = default;
 
     virtual errc_t getOrbitEpoch(TimePoint& orbitEpoch) const = 0;
 

--- a/src/AstCore/Orbit/Spacecraft/SpacecraftState.hpp
+++ b/src/AstCore/Orbit/Spacecraft/SpacecraftState.hpp
@@ -35,6 +35,10 @@ AST_NAMESPACE_BEGIN
 
 /// @brief 航天器状态，包含轨道状态、航天器参数（质量、面积、阻力系数、光压、密度、压力、温度等）
 /// @details 参考orekit的SpacecraftState类
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif
 class AST_CORE_API SpacecraftState: public ObjectNamed, public SpacecraftParam
 {
 public:
@@ -150,4 +154,7 @@ using ScState = SpacecraftState;
 
 /*! @} */
 
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 AST_NAMESPACE_END

--- a/src/AstCore/Orbit/Spacecraft/SpacecraftState.hpp
+++ b/src/AstCore/Orbit/Spacecraft/SpacecraftState.hpp
@@ -146,7 +146,7 @@ public:
     errc_t getStateEpoch(TimePoint& stateEpoch) const;
     void copyFrom(const SpacecraftState& srcState);
 private:
-    HState orbitState_;                 ///< 轨道状态
+    HState orbitState_{};                ///< 轨道状态
 };
 
 

--- a/src/AstCore/Orbit/State/State.cpp
+++ b/src/AstCore/Orbit/State/State.cpp
@@ -81,7 +81,7 @@ PState State::New(State &state, EStateType type)
 }
 
 State::State(const State& state)
-    : gm_{state.gm_}
+    : frame_(), gm_{state.gm_}, stateEpoch_()
 {
     auto frame = state.frame_;
     auto epoch = state.stateEpoch_;

--- a/src/AstCore/Orbit/State/State.hpp
+++ b/src/AstCore/Orbit/State/State.hpp
@@ -217,9 +217,9 @@ PROPERTIES:
     void setStateEpoch(EventTime* stateEpoch);
 
 protected:
-    SharedPtr<Frame>        frame_;                ///< 参考坐标系
+    SharedPtr<Frame>        frame_{};               ///< 参考坐标系
     double                  gm_{0};                ///< 引力常数
-    SharedPtr<EventTime>    stateEpoch_;           ///< 状态历元时间
+    SharedPtr<EventTime>    stateEpoch_{};          ///< 状态历元时间
 };
 
 /*! @} */

--- a/src/AstCore/Propagator/EventDetector/DetectorBodyRelated.hpp
+++ b/src/AstCore/Propagator/EventDetector/DetectorBodyRelated.hpp
@@ -44,7 +44,7 @@ PROPERTIES:
     Body* body() const {return body_.get();}
     void setBody(Body* body) {body_ = body;}
 private:
-    WeakPtr<Body> body_;
+    WeakPtr<Body> body_{};
 };
 
 

--- a/src/AstCore/Propagator/EventDetector/DetectorEpoch.hpp
+++ b/src/AstCore/Propagator/EventDetector/DetectorEpoch.hpp
@@ -37,7 +37,7 @@ public:
     void setGoal(const TimePoint& time);
     const TimePoint& goal() const{return goal_;}
 private:
-    TimePoint goal_;        ///< 目标时间
+    TimePoint goal_{};        ///< 目标时间
 };
 
 AST_NAMESPACE_END

--- a/src/AstCore/Propagator/EventDetector/DetectorPointRelated.hpp
+++ b/src/AstCore/Propagator/EventDetector/DetectorPointRelated.hpp
@@ -45,7 +45,7 @@ public:
     Point* point() const { return point_.get(); }
     void setPoint(Point* point) { point_ = point; }
 private:
-    WeakPtr<Point> point_;
+    WeakPtr<Point> point_{};
 };
 
 /*! @} */

--- a/src/AstCore/Propagator/EventDetector/DetectorUserSelect.hpp
+++ b/src/AstCore/Propagator/EventDetector/DetectorUserSelect.hpp
@@ -47,7 +47,7 @@ PROPERTIES:
     ScStateCalculation* calculation() const{return calculation_.get();}
     void setCalculation(ScStateCalculation* calculation){calculation_ = calculation;}
 private:
-    WeakPtr<ScStateCalculation> calculation_;
+    WeakPtr<ScStateCalculation> calculation_{};
 };
 
 /*! @} */

--- a/src/AstCore/Propagator/EventDetector/EventDetector.cpp
+++ b/src/AstCore/Propagator/EventDetector/EventDetector.cpp
@@ -36,11 +36,15 @@ class ODEEventDetectorWrap: public ODEEventDetector
 {
 public:
     ODEEventDetectorWrap(EventDetector* eventDetector, StateMapper* stateMapper)
-        : eventDetector_(eventDetector)
+        : spacecraftState_()
+        , eventDetector_(eventDetector)
         , stateMapper_(stateMapper)
     {
         spacecraftState_ = SpacecraftState::NewDefault();
     }
+
+    ODEEventDetectorWrap(const ODEEventDetectorWrap&) = delete;
+    ODEEventDetectorWrap& operator=(const ODEEventDetectorWrap&) = delete;
     ~ODEEventDetectorWrap() override = default;
     double getValue(const double* y, double x) const override
     {

--- a/src/AstCore/Propagator/EventDetector/EventDetector.cpp
+++ b/src/AstCore/Propagator/EventDetector/EventDetector.cpp
@@ -36,11 +36,10 @@ class ODEEventDetectorWrap: public ODEEventDetector
 {
 public:
     ODEEventDetectorWrap(EventDetector* eventDetector, StateMapper* stateMapper)
-        : spacecraftState_()
+        : spacecraftState_(SpacecraftState::NewDefault())
         , eventDetector_(eventDetector)
         , stateMapper_(stateMapper)
     {
-        spacecraftState_ = SpacecraftState::NewDefault();
     }
 
     ODEEventDetectorWrap(const ODEEventDetectorWrap&) = delete;

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockDerivative.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockDerivative.hpp
@@ -53,7 +53,7 @@ public:
     std::vector<DataPort>& getDerivativePorts() { return derivativePorts_; }
     
 protected:
-    std::vector<DataPort> derivativePorts_;  // 导数端口
+    std::vector<DataPort> derivativePorts_{};  // 导数端口
 };
 
 AST_NAMESPACE_END

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockDrag.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockDrag.hpp
@@ -57,6 +57,10 @@ class AST_CORE_API BlockDrag: public BlockDerivative
 {
 public:
     BlockDrag();
+
+    BlockDrag(const BlockDrag&) = delete;
+    BlockDrag& operator=(const BlockDrag&) = delete;
+
     BlockDrag(Atmosphere* atmosphere, double dragCoefficient, double dragArea, Frame* propagationFrame);
 
     ~BlockDrag() override;

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockDragPartial.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockDragPartial.hpp
@@ -74,6 +74,10 @@ class AST_CORE_API BlockDragPartial : public BlockDrag
 {
 public:
     BlockDragPartial();
+
+    BlockDragPartial(const BlockDragPartial&) = delete;
+    BlockDragPartial& operator=(const BlockDragPartial&) = delete;
+
     BlockDragPartial(Atmosphere* atmosphere, double dragCoefficient, double dragArea, Frame* propagationFrame);
 
     errc_t run(const SimTime& simTime) override;

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockDragSensitivity.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockDragSensitivity.hpp
@@ -56,6 +56,10 @@ class AST_CORE_API BlockDragSensitivity : public BlockDerivative
 {
 public:
     BlockDragSensitivity();
+
+    BlockDragSensitivity(const BlockDragSensitivity&) = delete;
+    BlockDragSensitivity& operator=(const BlockDragSensitivity&) = delete;
+
     ~BlockDragSensitivity() override = default;
 
     errc_t run(const SimTime& simTime) override;

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockDynamicSystem.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockDynamicSystem.hpp
@@ -140,12 +140,12 @@ protected:
     A_DISABLE_COPY(BlockDynamicSystem);
     using StateMap = std::unordered_map<Identifier*, double*>;
 
-    std::vector<BlockDerivative*>   derivativeBlocks_;  // 状态量导数函数块
-    std::vector<double>             state_;             // 状态量
-    std::vector<double>             accumulate_;        // 累加状态量
-    std::vector<double>             derivative_;        // 状态量导数
-    StateMap                        stateMap_;          // 状态量映射表
-    StateMap                        derivativeMap_;     // 状态量导数映射表
+    std::vector<BlockDerivative*>   derivativeBlocks_{}; // 状态量导数函数块
+    std::vector<double>             state_{};            // 状态量
+    std::vector<double>             accumulate_{};       // 累加状态量
+    std::vector<double>             derivative_{};       // 状态量导数
+    StateMap                        stateMap_{};         // 状态量映射表
+    StateMap                        derivativeMap_{};    // 状态量导数映射表
 };
 
 

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockDynamicSystem.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockDynamicSystem.hpp
@@ -91,17 +91,25 @@ public:
     /// @param y 状态量数据指针
     void setStateData(const double* y) { state_.assign(y, y + this->size()); }
 
+    #ifdef _MSC_VER
+    #pragma warning(push, 0)
+    #endif
+
     /// @brief 获取状态量导数数据指针
     /// @param dydt 状态量导数数据指针
-    void getDerivativeData(double* dydt) const { std::copy(derivative_.begin(), derivative_.end(), dydt); }
+    void getDerivativeData(double* dydt) const { std::copy_n(derivative_.begin(), derivative_.size(), dydt); }
 
     /// @brief 填充状态量导数数据
     /// @param value 状态量导数值
-    void fillDerivativeData(double value) { std::fill(derivative_.begin(), derivative_.end(), value); }
+    void fillDerivativeData(double value) { std::fill_n(derivative_.begin(), derivative_.size(), value); }
 
     /// @brief 填充累加状态量数据
     /// @param value 累加状态量值
-    void fillAccumulateData(double value) { std::fill(accumulate_.begin(), accumulate_.end(), value); }
+    void fillAccumulateData(double value) { std::fill_n(accumulate_.begin(), accumulate_.size(), value); }
+    
+    #ifdef _MSC_VER
+    #pragma warning(pop)
+    #endif
 
     /// @brief 初始化
     errc_t initialize();

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockDynamicSystem.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockDynamicSystem.hpp
@@ -89,7 +89,7 @@ public:
 
     /// @brief 填充状态量数据
     /// @param y 状态量数据指针
-    void setStateData(const double* y) { std::copy(y, y + this->size(), state_.begin()); }
+    void setStateData(const double* y) { state_.assign(y, y + this->size()); }
 
     /// @brief 获取状态量导数数据指针
     /// @param dydt 状态量导数数据指针

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockGravity.cpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockGravity.cpp
@@ -35,6 +35,7 @@ BlockGravity::BlockGravity()
     , accGravityPtr_{&vectorBuffer_}
     , velocityDerivativePtr_{&vectorBuffer_}
     , vectorBuffer_{}
+    , gravityCalculator_()
 {
     init();
 }

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockGravity.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockGravity.hpp
@@ -57,6 +57,9 @@ public:
     BlockGravity(const GravityField &gravityField, int degree, int order, Axes* gravityAxes=nullptr, Axes* propagationAxes=nullptr);
     BlockGravity(GravityField &&gravityField, int degree, int order, Axes* gravityAxes=nullptr, Axes* propagationAxes=nullptr);
 
+    BlockGravity(const BlockGravity&) = delete;
+    BlockGravity& operator=(const BlockGravity&) = delete;
+
     errc_t run(const SimTime& simTime) override;
 
     /// @brief 设置是否考虑重力场系数变化

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockGravityPartial.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockGravityPartial.hpp
@@ -67,6 +67,9 @@ public:
     BlockGravityPartial(GravityField &&gravityField, int degree, int order,
                         Axes* gravityAxes=nullptr, Axes* propagationAxes=nullptr);
 
+    BlockGravityPartial(const BlockGravityPartial&) = delete;
+    BlockGravityPartial& operator=(const BlockGravityPartial&) = delete;
+
     void setDegreeForPartial(int degree){this->gravityCalculator_.setDegreeForPartial(degree);}
     
     void setOrderForPartial(int order){this->gravityCalculator_.setOrderForPartial(order);}

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockMass.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockMass.hpp
@@ -44,6 +44,10 @@ class AST_CORE_API BlockMass: public BlockDerivative
 {
 public:
     explicit BlockMass(double mass);
+
+    BlockMass(const BlockMass&) = delete;
+    BlockMass& operator=(const BlockMass&) = delete;
+
     ~BlockMass();
     errc_t run(const SimTime& simTime) final{return 0;}
 protected:

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockMotion.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockMotion.hpp
@@ -45,6 +45,9 @@ class AST_CORE_API BlockMotion : public BlockDerivative
 public:
     BlockMotion();
 
+    BlockMotion(const BlockMotion&) = delete;
+    BlockMotion& operator=(const BlockMotion&) = delete;
+
     errc_t run(const SimTime& simTime) override;
 
 protected:

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockMotionPartial.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockMotionPartial.hpp
@@ -60,6 +60,9 @@ class AST_CORE_API BlockMotionPartial : public BlockMotion
 public:
     BlockMotionPartial();
 
+    BlockMotionPartial(const BlockMotionPartial&) = delete;
+    BlockMotionPartial& operator=(const BlockMotionPartial&) = delete;
+
     errc_t run(const SimTime& simTime) override;
 private:
     void init();

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockSRP.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockSRP.hpp
@@ -76,6 +76,10 @@ class AST_CORE_API BlockSRP : public BlockDerivative
 {
 public:
     BlockSRP();
+
+    BlockSRP(const BlockSRP&) = delete;
+    BlockSRP& operator=(const BlockSRP&) = delete;
+
     /// @param sun 太阳
     /// @param cr 光压系数
     /// @param srpArea SRP面积

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockSRPPartial.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockSRPPartial.hpp
@@ -75,6 +75,9 @@ public:
     BlockSRPPartial();
     BlockSRPPartial(EclipseCalculator* eclipseCalculator, double cr, double srpArea, Frame* propagationFrame);
 
+    BlockSRPPartial(const BlockSRPPartial&) = delete;
+    BlockSRPPartial& operator=(const BlockSRPPartial&) = delete;
+
     errc_t run(const SimTime& simTime) override;
 
     /// @brief 设置是否启用SRP综合参数K敏感度传播

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockSRPSensitivity.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockSRPSensitivity.hpp
@@ -56,6 +56,10 @@ class AST_CORE_API BlockSRPSensitivity : public BlockDerivative
 {
 public:
     BlockSRPSensitivity();
+
+    BlockSRPSensitivity(const BlockSRPSensitivity&) = delete;
+    BlockSRPSensitivity& operator=(const BlockSRPSensitivity&) = delete;
+
     ~BlockSRPSensitivity() override = default;
 
     errc_t run(const SimTime& simTime) override;

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockStateTransitionMatrix.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockStateTransitionMatrix.hpp
@@ -72,6 +72,10 @@ class AST_CORE_API BlockStateTransitionMatrix : public BlockDerivative
 {
 public:
     BlockStateTransitionMatrix();
+
+    BlockStateTransitionMatrix(const BlockStateTransitionMatrix&) = delete;
+    BlockStateTransitionMatrix& operator=(const BlockStateTransitionMatrix&) = delete;
+
     ~BlockStateTransitionMatrix() override = default;
 
     errc_t run(const SimTime& simTime) override;

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyGravity.cpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyGravity.cpp
@@ -46,6 +46,7 @@ BlockThirdBodyGravity::BlockThirdBodyGravity()
     , gravityAxes_{nullptr}
     , propagationAxes_{nullptr}
     , propagationFrame_{nullptr}
+    , gravityCalculator_()
 {
     init();
 }

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyGravity.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyGravity.hpp
@@ -67,6 +67,10 @@ class AST_CORE_API BlockThirdBodyGravity : public BlockDerivative
 {
 public:
     BlockThirdBodyGravity();
+
+    BlockThirdBodyGravity(const BlockThirdBodyGravity&) = delete;
+    BlockThirdBodyGravity& operator=(const BlockThirdBodyGravity&) = delete;
+
     explicit BlockThirdBodyGravity(Point* thirdBody, GravityField&& gravityField,
                                    int degree, int order, Axes* gravityAxes,
                                    Frame* propagationFrame);

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyGravityPartial.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyGravityPartial.hpp
@@ -72,6 +72,10 @@ class AST_CORE_API BlockThirdBodyGravityPartial : public BlockThirdBodyGravity
 {
 public:
     BlockThirdBodyGravityPartial();
+
+    BlockThirdBodyGravityPartial(const BlockThirdBodyGravityPartial&) = delete;
+    BlockThirdBodyGravityPartial& operator=(const BlockThirdBodyGravityPartial&) = delete;
+
     explicit BlockThirdBodyGravityPartial(Point* thirdBody, GravityField&& gravityField,
                                           int degree, int order, Axes* gravityAxes,
                                           Frame* propagationFrame);

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyPointMass.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyPointMass.hpp
@@ -52,6 +52,10 @@ class AST_CORE_API BlockThirdBodyPointMass : public BlockDerivative
 {
 public:
     BlockThirdBodyPointMass();
+
+    BlockThirdBodyPointMass(const BlockThirdBodyPointMass&) = delete;
+    BlockThirdBodyPointMass& operator=(const BlockThirdBodyPointMass&) = delete;
+
     explicit BlockThirdBodyPointMass(Point* thirdBody, double thirdBodyGM, Frame* propagationFrame);
 
     errc_t run(const SimTime& simTime) override;

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyPointMassPartial.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockThirdBodyPointMassPartial.hpp
@@ -69,6 +69,10 @@ class AST_CORE_API BlockThirdBodyPointMassPartial : public BlockThirdBodyPointMa
 {
 public:
     BlockThirdBodyPointMassPartial();
+
+    BlockThirdBodyPointMassPartial(const BlockThirdBodyPointMassPartial&) = delete;
+    BlockThirdBodyPointMassPartial& operator=(const BlockThirdBodyPointMassPartial&) = delete;
+
     explicit BlockThirdBodyPointMassPartial(Point* thirdBody, double thirdBodyGM, Frame* propagationFrame);
 
     errc_t run(const SimTime& simTime) override;

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockTwoBody.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockTwoBody.hpp
@@ -52,6 +52,10 @@ class AST_CORE_API BlockTwoBody : public BlockDerivative
 {
 public:
     BlockTwoBody();
+
+    BlockTwoBody(const BlockTwoBody&) = delete;
+    BlockTwoBody& operator=(const BlockTwoBody&) = delete;
+
     explicit BlockTwoBody(double twoBodyGM);
 
     errc_t run(const SimTime& simTime) override;

--- a/src/AstCore/Propagator/HPOP/BlockAstro/BlockTwoBodyPartial.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockAstro/BlockTwoBodyPartial.hpp
@@ -64,6 +64,10 @@ class AST_CORE_API BlockTwoBodyPartial : public BlockTwoBody
 {
 public:
     BlockTwoBodyPartial();
+
+    BlockTwoBodyPartial(const BlockTwoBodyPartial&) = delete;
+    BlockTwoBodyPartial& operator=(const BlockTwoBodyPartial&) = delete;
+
     explicit BlockTwoBodyPartial(double twoBodyGM);
 
     errc_t run(const SimTime& simTime) override;

--- a/src/AstCore/Propagator/HPOP/BlockCommon/Discontinuities/BlockDeadZone.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/Discontinuities/BlockDeadZone.hpp
@@ -30,6 +30,9 @@ class AST_CORE_API BlockDeadZone : public FuncBlock
 public:
     BlockDeadZone();
 
+    BlockDeadZone(const BlockDeadZone&) = delete;
+    BlockDeadZone& operator=(const BlockDeadZone&) = delete;
+
     errc_t run(const SimTime &simTime) override;
     
     /// @brief 设置死区下限

--- a/src/AstCore/Propagator/HPOP/BlockCommon/Discontinuities/BlockSaturation.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/Discontinuities/BlockSaturation.hpp
@@ -31,6 +31,9 @@ class AST_CORE_API BlockSaturation: public FuncBlock
 public:
     explicit BlockSaturation(double lowerLimit = -1.0, double upperLimit = 1.0);
 
+    BlockSaturation(const BlockSaturation&) = delete;
+    BlockSaturation& operator=(const BlockSaturation&) = delete;
+
     errc_t run(const SimTime &simTime) override;
     
     /// @brief 设置下限

--- a/src/AstCore/Propagator/HPOP/BlockCommon/LogicAndBitOperations/BlockLogicalOperator.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/LogicAndBitOperations/BlockLogicalOperator.hpp
@@ -39,6 +39,9 @@ class AST_CORE_API BlockLogicalOperator: public FuncBlock
 public:
     explicit BlockLogicalOperator(ELogicalOperatorType type = ELogicalOperatorType::eAnd);
 
+    BlockLogicalOperator(const BlockLogicalOperator&) = delete;
+    BlockLogicalOperator& operator=(const BlockLogicalOperator&) = delete;
+
     errc_t run(const SimTime &simTime) override;
     
     /// @brief 设置逻辑运算符类型

--- a/src/AstCore/Propagator/HPOP/BlockCommon/LogicAndBitOperations/BlockRelationalOperator.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/LogicAndBitOperations/BlockRelationalOperator.hpp
@@ -41,6 +41,9 @@ class AST_CORE_API BlockRelationalOperator: public FuncBlock
 public:
     explicit BlockRelationalOperator(ERelationalOperatorType type = ERelationalOperatorType::eEqual);
 
+    BlockRelationalOperator(const BlockRelationalOperator&) = delete;
+    BlockRelationalOperator& operator=(const BlockRelationalOperator&) = delete;
+
     errc_t run(const SimTime &simTime) override;
     
     /// @brief 设置关系运算符类型

--- a/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockAbs.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockAbs.hpp
@@ -30,6 +30,9 @@ class AST_CORE_API BlockAbs : public FuncBlock
 public:
     BlockAbs();
 
+    BlockAbs(const BlockAbs&) = delete;
+    BlockAbs& operator=(const BlockAbs&) = delete;
+
     errc_t run(const SimTime &simTime) override;
 protected:
     double* input_{nullptr};  // 输入值

--- a/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockDivide.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockDivide.hpp
@@ -30,6 +30,9 @@ class AST_CORE_API BlockDivide : public FuncBlock
 public:
     BlockDivide();
 
+    BlockDivide(const BlockDivide&) = delete;
+    BlockDivide& operator=(const BlockDivide&) = delete;
+
     errc_t run(const SimTime &simTime) override;
 protected:
     double* numerator_{nullptr};  // 分子

--- a/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockDot.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockDot.hpp
@@ -30,6 +30,9 @@ class AST_CORE_API BlockDot : public FuncBlock
 public:
     BlockDot();
 
+    BlockDot(const BlockDot&) = delete;
+    BlockDot& operator=(const BlockDot&) = delete;
+
     errc_t run(const SimTime &simTime) override;
 protected:
     double* vector1_{nullptr};  // 第一个向量

--- a/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockGain.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockGain.hpp
@@ -32,6 +32,10 @@ class AST_CORE_API BlockGain : public FuncBlock
 {
 public:
     BlockGain();
+
+    BlockGain(const BlockGain&) = delete;
+    BlockGain& operator=(const BlockGain&) = delete;
+
     ~BlockGain() = default;
 
     errc_t run(const SimTime& simTime) override;

--- a/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockProduct.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockProduct.hpp
@@ -31,6 +31,9 @@ class AST_CORE_API BlockProduct: public FuncBlock
 public:
     BlockProduct();
 
+    BlockProduct(const BlockProduct&) = delete;
+    BlockProduct& operator=(const BlockProduct&) = delete;
+
     errc_t run(const SimTime &simTime) override;
 
 protected:

--- a/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockSign.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockSign.hpp
@@ -30,6 +30,9 @@ class AST_CORE_API BlockSign : public FuncBlock
 public:
     BlockSign();
 
+    BlockSign(const BlockSign&) = delete;
+    BlockSign& operator=(const BlockSign&) = delete;
+
     errc_t run(const SimTime &simTime) override;
 protected:
     double* input_{nullptr};  // 输入值

--- a/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockSubtract.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockSubtract.hpp
@@ -30,6 +30,9 @@ class AST_CORE_API BlockSubtract : public FuncBlock
 public:
     BlockSubtract();
 
+    BlockSubtract(const BlockSubtract&) = delete;
+    BlockSubtract& operator=(const BlockSubtract&) = delete;
+
     errc_t run(const SimTime &simTime) override;
 protected:
     double* input1_{nullptr};  // 被减数

--- a/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockSum.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockSum.hpp
@@ -32,6 +32,9 @@ class AST_CORE_API BlockSum: public FuncBlock
 public:
     BlockSum();
 
+    BlockSum(const BlockSum&) = delete;
+    BlockSum& operator=(const BlockSum&) = delete;
+
     errc_t run(const SimTime &simTime) override;
 protected:
     double* input1_{nullptr};

--- a/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockUnaryMinus.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/MathOperations/BlockUnaryMinus.hpp
@@ -30,6 +30,9 @@ class AST_CORE_API BlockUnaryMinus : public FuncBlock
 public:
     BlockUnaryMinus();
 
+    BlockUnaryMinus(const BlockUnaryMinus&) = delete;
+    BlockUnaryMinus& operator=(const BlockUnaryMinus&) = delete;
+
     errc_t run(const SimTime &simTime) override;
 protected:
     double* input_{nullptr};  // 输入值

--- a/src/AstCore/Propagator/HPOP/BlockCommon/SignalRouting/BlockSwitch.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/SignalRouting/BlockSwitch.hpp
@@ -31,6 +31,9 @@ class AST_CORE_API BlockSwitch: public FuncBlock
 public:
     BlockSwitch();
 
+    BlockSwitch(const BlockSwitch&) = delete;
+    BlockSwitch& operator=(const BlockSwitch&) = delete;
+
     errc_t run(const SimTime &simTime) override;
     
     /// @brief 设置阈值

--- a/src/AstCore/Propagator/HPOP/BlockCommon/Sinks/BlockOut.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/Sinks/BlockOut.hpp
@@ -31,6 +31,9 @@ class AST_CORE_API BlockOut: public FuncBlock
 public:
     BlockOut();
 
+    BlockOut(const BlockOut&) = delete;
+    BlockOut& operator=(const BlockOut&) = delete;
+
     errc_t run(const SimTime &simTime) override;
     
     /// @brief 获取输出值

--- a/src/AstCore/Propagator/HPOP/BlockCommon/Sinks/BlockTerminator.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/Sinks/BlockTerminator.hpp
@@ -31,6 +31,9 @@ class AST_CORE_API BlockTerminator: public FuncBlock
 public:
     BlockTerminator();
 
+    BlockTerminator(const BlockTerminator&) = delete;
+    BlockTerminator& operator=(const BlockTerminator&) = delete;
+
     errc_t run(const SimTime &simTime) override;
     
     /// @brief 获取输入值

--- a/src/AstCore/Propagator/HPOP/BlockCommon/Sources/BlockConstant.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/Sources/BlockConstant.hpp
@@ -31,6 +31,9 @@ class AST_CORE_API BlockConstant: public FuncBlock
 public:
     explicit BlockConstant(double value = 0.0);
 
+    BlockConstant(const BlockConstant&) = delete;
+    BlockConstant& operator=(const BlockConstant&) = delete;
+
     errc_t run(const SimTime &simTime) override;
     
     /// @brief 设置常量值

--- a/src/AstCore/Propagator/HPOP/BlockCommon/Sources/BlockIn.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/Sources/BlockIn.hpp
@@ -31,6 +31,9 @@ class AST_CORE_API BlockIn: public FuncBlock
 public:
     BlockIn();
 
+    BlockIn(const BlockIn&) = delete;
+    BlockIn& operator=(const BlockIn&) = delete;
+
     errc_t run(const SimTime &simTime) override;
     
     /// @brief 设置输入值

--- a/src/AstCore/Propagator/HPOP/BlockCommon/Sources/BlockSin.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockCommon/Sources/BlockSin.hpp
@@ -30,6 +30,10 @@ class AST_CORE_API BlockSin : public FuncBlock
 {
 public:
     BlockSin();
+
+    BlockSin(const BlockSin&) = delete;
+    BlockSin& operator=(const BlockSin&) = delete;
+
     ~BlockSin() = default;
 
     errc_t run(const SimTime& simTime) final;

--- a/src/AstCore/Propagator/HPOP/BlockSystem.hpp
+++ b/src/AstCore/Propagator/HPOP/BlockSystem.hpp
@@ -46,7 +46,7 @@ public:
     void clearBlocks();
 
 protected:
-    std::vector<FuncBlock*> blocks_;    // 子系统块中的函数块
+    std::vector<FuncBlock*> blocks_{};    // 子系统块中的函数块
 };
 
 

--- a/src/AstCore/Propagator/HPOP/FuncBlock.hpp
+++ b/src/AstCore/Propagator/HPOP/FuncBlock.hpp
@@ -151,8 +151,8 @@ public:
     static errc_t connect(FuncBlock* src, size_t srcPortIndex, FuncBlock* dst, size_t dstPortIndex);
 
 protected:
-    std::vector<DataPort> inputPorts_;
-    std::vector<DataPort> outputPorts_;
+    std::vector<DataPort> inputPorts_{};
+    std::vector<DataPort> outputPorts_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstCore/Propagator/HPOP/HPOP.cpp
+++ b/src/AstCore/Propagator/HPOP/HPOP.cpp
@@ -154,7 +154,7 @@ private:
 };
 
 HPOP::HPOP()
-    : stateMapper_(new HPOPStateMapper())
+    : equation_(), integrator_(), stateMapper_(new HPOPStateMapper())
 {
 
 }

--- a/src/AstCore/Propagator/HPOP/HPOPEquation.cpp
+++ b/src/AstCore/Propagator/HPOP/HPOPEquation.cpp
@@ -48,7 +48,7 @@
 AST_NAMESPACE_BEGIN
 
 HPOPEquation::HPOPEquation()
-    : propFrame_{}
+    : dynamicSystem_(), propFrame_{}
 {
 
 }

--- a/src/AstCore/Propagator/HPOP/StateMapper.hpp
+++ b/src/AstCore/Propagator/HPOP/StateMapper.hpp
@@ -105,7 +105,7 @@ public:
     /// @param[in] epoch 参考历元
     void setEpoch(TimePoint epoch){epoch_ = epoch;}
 private:
-    TimePoint epoch_;   ///< 参考历元
+    TimePoint epoch_{};   ///< 参考历元
 };
 
 /*! @} */

--- a/src/AstCore/SolarSystem/CelestialBody.hpp
+++ b/src/AstCore/SolarSystem/CelestialBody.hpp
@@ -328,29 +328,29 @@ protected:
 
     A_DISABLE_COPY(CelestialBody)
 private:
-    WeakPtr<SolarSystem>        solarSystem_;                    ///< 太阳系指针
-    SharedPtr<CelestialBody>    parent_;                         ///< 父天体
+    WeakPtr<SolarSystem>        solarSystem_{};                    ///< 太阳系指针
+    SharedPtr<CelestialBody>    parent_{};                         ///< 父天体
     double                      gm_{0.0};                        ///< 引力常数
     double                      systemGM_{0.0};                  ///< 系统引力常数
     double                      radius_{0.0};                    ///< 天体半径
     int                         jplSpiceId_{-1};                 ///< JPL SPICE ID
     int                         jplIndex_{-1};                   ///< JPL DE Index
-    GravityField                gravityField_;                   ///< 重力场
-    SharedPtr<BodyShape>        shape_;                          ///< 天体形状
-    SharedPtr<BodyOrientation>  orientation_;                    ///< 天体姿态
-    SharedPtr<BodyEphemeris>    ephemeris_;                      ///< 天体星历
+    GravityField                gravityField_{};                   ///< 重力场
+    SharedPtr<BodyShape>        shape_{};                          ///< 天体形状
+    SharedPtr<BodyOrientation>  orientation_{};                    ///< 天体姿态
+    SharedPtr<BodyEphemeris>    ephemeris_{};                      ///< 天体星历
 
-    SharedPtr<AxesBodyInertial> axesInertial_;                   ///< 天体惯性轴
-    SharedPtr<AxesBodyFixed>    axesFixed_;                      ///< 天体固定轴
-    SharedPtr<AxesBodyMOD>      axesMOD_;                        ///< 天体MOD轴
-    SharedPtr<AxesBodyTOD>      axesTOD_;                        ///< 天体TOD轴
+    SharedPtr<AxesBodyInertial> axesInertial_{};                   ///< 天体惯性轴
+    SharedPtr<AxesBodyFixed>    axesFixed_{};                      ///< 天体固定轴
+    SharedPtr<AxesBodyMOD>      axesMOD_{};                        ///< 天体MOD轴
+    SharedPtr<AxesBodyTOD>      axesTOD_{};                        ///< 天体TOD轴
 
-    mutable WeakPtr<Frame>      frameInertial_;                  ///< 天体惯性坐标系
-    mutable WeakPtr<Frame>      frameFixed_;                     ///< 天体固连坐标系
+    mutable WeakPtr<Frame>      frameInertial_{};                  ///< 天体惯性坐标系
+    mutable WeakPtr<Frame>      frameFixed_{};                     ///< 天体固连坐标系
 
-    mutable SharedPtr<BodyEphemeris> ephemerisDE_;               ///< 天体DE星历
-    mutable SharedPtr<BodyEphemeris> ephemerisSpice_;            ///< 天体SPICE星历(spk)
-    mutable SharedPtr<BodyEphemeris> ephemerisSpiceBarycenter_;  ///< 天体星系质心SPICE星历(考虑其卫星时的天体系质心)
+    mutable SharedPtr<BodyEphemeris> ephemerisDE_{};              ///< 天体DE星历
+    mutable SharedPtr<BodyEphemeris> ephemerisSpice_{};           ///< 天体SPICE星历(spk)
+    mutable SharedPtr<BodyEphemeris> ephemerisSpiceBarycenter_{}; ///< 天体星系质心SPICE星历(考虑其卫星时的天体系质心)
 };
 
 

--- a/src/AstCore/SolarSystem/CelestialBody.hpp
+++ b/src/AstCore/SolarSystem/CelestialBody.hpp
@@ -482,4 +482,4 @@ using PBody = PCelestialBody;                           ///< 天体指针
 AST_NAMESPACE_END
  
 
-
+#include "SolarSystem.hpp"

--- a/src/AstCore/SolarSystem/Ephemeris/BodyEphemerisDE.hpp
+++ b/src/AstCore/SolarSystem/Ephemeris/BodyEphemerisDE.hpp
@@ -39,6 +39,9 @@ public:
     AST_PROPERT(JplIndex)
     BodyEphemerisDE() = default;
 
+    BodyEphemerisDE(const BodyEphemerisDE&) = delete;
+    BodyEphemerisDE& operator=(const BodyEphemerisDE&) = delete;
+
     BodyEphemerisDE(int jplIndex)
         : jplIndex_(jplIndex)
     {}

--- a/src/AstCore/SolarSystem/Ephemeris/BodyEphemerisSPK.hpp
+++ b/src/AstCore/SolarSystem/Ephemeris/BodyEphemerisSPK.hpp
@@ -40,13 +40,18 @@ public:
     AST_OBJECT(BodyEphemerisSPK)
     AST_PROPERT(SpiceIndex)
     BodyEphemerisSPK() = default;
+
+    BodyEphemerisSPK(const BodyEphemerisSPK&) = delete;
+    BodyEphemerisSPK& operator=(const BodyEphemerisSPK&) = delete;
     
     BodyEphemerisSPK(int spiceIndex)
         : spiceIndex_(spiceIndex)
+        , spk_()
     {}
     BodyEphemerisSPK(CelestialBody* body)
         : body_(body)
         , spiceIndex_(body->getJplSpiceId())
+        , spk_()
     {}
 
     ~BodyEphemerisSPK() override = default;
@@ -67,7 +72,7 @@ PROPERTIES:
 protected:
     CelestialBody* body_{nullptr};
     int            spiceIndex_{-1};
-    JplSpk         spk_;
+    JplSpk         spk_{};
 };
 
 

--- a/src/AstCore/SolarSystem/Orientation/MoonOrientation.hpp
+++ b/src/AstCore/SolarSystem/Orientation/MoonOrientation.hpp
@@ -48,7 +48,7 @@ public:
     RotationalData& rotationalData(){return rotation_;}
     const RotationalData& rotationalData() const {return rotation_;}
 private:
-    RotationalData rotation_;       ///< 月球的旋转系数
+    RotationalData rotation_{};       ///< 月球的旋转系数
 };
 
 /*! @} */

--- a/src/AstCore/SolarSystem/Orientation/RotationElement.hpp
+++ b/src/AstCore/SolarSystem/Orientation/RotationElement.hpp
@@ -72,7 +72,7 @@ protected:
     double rate_ {0.0};
     double rateDot_ {0.0};
     bool isSine_ {false};
-    std::vector<Coefficient> coefficients_;
+    std::vector<Coefficient> coefficients_{};
 };
 
 

--- a/src/AstCore/SolarSystem/Orientation/RotationalData.hpp
+++ b/src/AstCore/SolarSystem/Orientation/RotationalData.hpp
@@ -111,10 +111,10 @@ public:
     
 
 protected:
-    TimePoint rotationEpoch_;           ///< 旋转历元
-    RotationElement rightAscension_;
-    RotationElement declination_;
-    RotationElement rotation_;
+    TimePoint rotationEpoch_{};          ///< 旋转历元
+    RotationElement rightAscension_{};
+    RotationElement declination_{};
+    RotationElement rotation_{};
 };
 
 /*! @} */

--- a/src/AstCore/SolarSystem/SolarSystem.hpp
+++ b/src/AstCore/SolarSystem/SolarSystem.hpp
@@ -160,27 +160,27 @@ protected:
 	using BodyVector = std::vector<SharedPtr<CelestialBody>>;
 
 	
-	SharedPtr<CelestialBody> solarSystemBarycenter_; ///< 太阳系质心
-	SharedPtr<CelestialBody> earthMoonBarycenter_;	 ///< 地月质心
+	SharedPtr<CelestialBody> solarSystemBarycenter_{}; ///< 太阳系质心
+	SharedPtr<CelestialBody> earthMoonBarycenter_{};	 ///< 地月质心
  
-	SharedPtr<CelestialBody> mercury_;				 ///< 水星
-	SharedPtr<CelestialBody> venus_;				 ///< 金星
-    SharedPtr<CelestialBody> earth_;				 ///< 地球
-    SharedPtr<CelestialBody> mars_;					 ///< 火星
-	SharedPtr<CelestialBody> jupiter_;				 ///< 木星
-	SharedPtr<CelestialBody> saturn_;				 ///< 土星
-	SharedPtr<CelestialBody> uranus_;				 ///< 天王星
-	SharedPtr<CelestialBody> neptune_;				 ///< 海王星
-	SharedPtr<CelestialBody> pluto_;				 ///< 冥王星
-    SharedPtr<CelestialBody> moon_;					 ///< 月球
-	SharedPtr<CelestialBody> sun_;					 ///< 太阳
+	SharedPtr<CelestialBody> mercury_{};				 ///< 水星
+	SharedPtr<CelestialBody> venus_{};				 ///< 金星
+    SharedPtr<CelestialBody> earth_{};				 ///< 地球
+    SharedPtr<CelestialBody> mars_{};					 ///< 火星
+	SharedPtr<CelestialBody> jupiter_{};				 ///< 木星
+	SharedPtr<CelestialBody> saturn_{};				 ///< 土星
+	SharedPtr<CelestialBody> uranus_{};				 ///< 天王星
+	SharedPtr<CelestialBody> neptune_{};				 ///< 海王星
+	SharedPtr<CelestialBody> pluto_{};				 ///< 冥王星
+    SharedPtr<CelestialBody> moon_{};					 ///< 月球
+	SharedPtr<CelestialBody> sun_{};					 ///< 太阳
  
-	BodyVector bodies_;							 	 ///< 太阳系天体集合
-	mutable BodyNameMap  nameMap_;					 ///< 太阳系天体映射表，可能存在别名映射
-	mutable BodyIndexMap jplIndexMap_;				 ///< 太阳系天体映射表，根据JPL索引映射
-	mutable BodyIndexMap spiceIdMap_;				 ///< 太阳系天体映射表，根据SPICE ID映射
+	BodyVector bodies_{};							 	 ///< 太阳系天体集合
+	mutable BodyNameMap  nameMap_{};					 ///< 太阳系天体映射表，可能存在别名映射
+	mutable BodyIndexMap jplIndexMap_{};				 ///< 太阳系天体映射表，根据JPL索引映射
+	mutable BodyIndexMap spiceIdMap_{};				 ///< 太阳系天体映射表，根据SPICE ID映射
 	bool			     isInit_{false};			 ///<  是否已初始化
-	std::string          dirpath_;				 	 ///< 太阳系数据目录路径
+	std::string          dirpath_{};				 	 ///< 太阳系数据目录路径
 };
 
 

--- a/src/AstCore/Time/IntervalList.hpp
+++ b/src/AstCore/Time/IntervalList.hpp
@@ -265,7 +265,7 @@ public:
     TimeList discrete(const TimePoint& epoch, double step) const;
 
 private:
-    std::vector<Interval> intervals_;   ///< 相对时间区间列表
+    std::vector<Interval> intervals_{};   ///< 相对时间区间列表
 };
 
 

--- a/src/AstCore/Time/TimeIntervalList.hpp
+++ b/src/AstCore/Time/TimeIntervalList.hpp
@@ -273,7 +273,7 @@ public:
 
 private:
     TimePoint    epoch_{};   ///< 参考历元
-    IntervalList intervals_; ///< 相对时间区间列表（相对于 epoch_）
+    IntervalList intervals_{}; ///< 相对时间区间列表（相对于 epoch_）
 };
 
 

--- a/src/AstCore/Time/TimeList.hpp
+++ b/src/AstCore/Time/TimeList.hpp
@@ -238,7 +238,7 @@ public:
 	const_iterator cend()  const { return end(); }
 
 private:
-	std::vector<double> seconds_;   ///< 相对于 epoch_ 的秒偏移量
+	std::vector<double> seconds_{};   ///< 相对于 epoch_ 的秒偏移量
 	TimePoint           epoch_{};   ///< 参考历元
 };
 

--- a/src/AstDataUpdate/DataUpdater.hpp
+++ b/src/AstDataUpdate/DataUpdater.hpp
@@ -53,15 +53,15 @@ public:
     /// @brief 数据文件条目信息
     struct DataFileEntry
     {
-        std::string name;          ///< 显示名称，如 "EOP (地球定向参数)"
-        std::string description;   ///< 详细说明
-        std::string url;           ///< 下载 URL（Celestrak）
-        std::string localPath;     ///< 本地文件绝对路径（来自 InitalizeConfig）
-        std::string fileDate;      ///< 文件内部记录的数据日期（UPDATED 字段）
-        int         backupCount;   ///< 已有备份数量
-        int         maxAgeDays;    ///< 过期阈值（天数）
-        bool        isOutdated;    ///< 是否建议更新
-        errc_t      lastError;     ///< 上次更新错误码（eNoError 表示成功）
+        std::string name{};          ///< 显示名称，如 "EOP (地球定向参数)"
+        std::string description{};   ///< 详细说明
+        std::string url{};           ///< 下载 URL（Celestrak）
+        std::string localPath{};     ///< 本地文件绝对路径（来自 InitalizeConfig）
+        std::string fileDate{};      ///< 文件内部记录的数据日期（UPDATED 字段）
+        int         backupCount{};   ///< 已有备份数量
+        int         maxAgeDays{};    ///< 过期阈值（天数）
+        bool        isOutdated{};    ///< 是否建议更新
+        errc_t      lastError{};     ///< 上次更新错误码（eNoError 表示成功）
     };
 
     DataUpdater() = default;

--- a/src/AstFault/CrashHandler.cpp
+++ b/src/AstFault/CrashHandler.cpp
@@ -1037,8 +1037,9 @@ static void _aCrashSpawnReporter(const char* logPath)
         cmdLine[pos++] = '"';
         cmdLine[pos] = '\0';
 
-        STARTUPINFOA si = { sizeof(STARTUPINFOA) };
-        PROCESS_INFORMATION pi = {};
+        STARTUPINFOA si{};
+        si.cb = sizeof(STARTUPINFOA);
+        PROCESS_INFORMATION pi{};
         si.dwFlags = STARTF_USESHOWWINDOW;
         si.wShowWindow = SW_SHOW;
 

--- a/src/AstGUI/Analyzer/UiAnalyzerMainWindow.hpp
+++ b/src/AstGUI/Analyzer/UiAnalyzerMainWindow.hpp
@@ -44,6 +44,9 @@ public:
     explicit UiAnalyzerMainWindow(QWidget* parent = nullptr);
     ~UiAnalyzerMainWindow() override;
 
+    UiAnalyzerMainWindow(const UiAnalyzerMainWindow&) = delete;
+    UiAnalyzerMainWindow& operator=(const UiAnalyzerMainWindow&) = delete;
+
     /// @brief 获取内部 UiStudyWorkbench 编辑器
     UiStudyWorkbench* studyWorkbenchEditor() const { return basicEditor_; }
 

--- a/src/AstGUI/Analyzer/UiResultView.hpp
+++ b/src/AstGUI/Analyzer/UiResultView.hpp
@@ -37,6 +37,8 @@ class AST_GUI_API UiResultView : public QWidget
     Q_OBJECT
 public:
     explicit UiResultView(QWidget* parent = nullptr);
+    UiResultView(const UiResultView&) = delete;
+    UiResultView& operator=(const UiResultView&) = delete;
 
     /// @brief 初始化表格列头
     /// @param variableNames 变量名列表
@@ -61,11 +63,11 @@ public:
 private:
     void setupUi();
 
-    QVBoxLayout*  layout_;
-    QTableWidget* table_;
-    QProgressBar* progressBar_;
-    QLabel*       progressLabel_;
-    QLabel*       timeLabel_;
+    QVBoxLayout*  layout_{};
+    QTableWidget* table_{};
+    QProgressBar* progressBar_{};
+    QLabel*       progressLabel_{};
+    QLabel*       timeLabel_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Analyzer/UiStudyWorkbench.hpp
+++ b/src/AstGUI/Analyzer/UiStudyWorkbench.hpp
@@ -42,6 +42,9 @@ class AST_GUI_API UiStudyWorkbench : public QWidget
 public:
     explicit UiStudyWorkbench(QWidget* parent = nullptr);
 
+    UiStudyWorkbench(const UiStudyWorkbench&) = delete;
+    UiStudyWorkbench& operator=(const UiStudyWorkbench&) = delete;
+
     /// @brief 绑定要编辑的 StudyWorkbench
     void setStudyWorkbench(StudyWorkbench* analyzer);
 
@@ -55,16 +58,16 @@ private:
     void setupUi();
     void rebuildCommandEditor();
 
-    WeakPtr<StudyWorkbench> analyzer_;
+    WeakPtr<StudyWorkbench> analyzer_{};
 
-    QSplitter*           varSplitter_;
-    UiExpressionBrowser* expressionBrowser_;
-    QTabWidget*          tabWidget_;
-    QSplitter*           splitter_;
-    UiVariableList*      inputsEditor_;
-    UiVariableList*      outputsEditor_;
-    QStackedWidget*      commandStack_;
-    QLabel*              placeholderLabel_;
+    QSplitter*           varSplitter_{};
+    UiExpressionBrowser* expressionBrowser_{};
+    QTabWidget*          tabWidget_{};
+    QSplitter*           splitter_{};
+    UiVariableList*      inputsEditor_{};
+    UiVariableList*      outputsEditor_{};
+    QStackedWidget*      commandStack_{};
+    QLabel*              placeholderLabel_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Analyzer/UiSweepOutputList.hpp
+++ b/src/AstGUI/Analyzer/UiSweepOutputList.hpp
@@ -37,6 +37,8 @@ class AST_GUI_API UiSweepOutputList : public QWidget
     Q_OBJECT
 public:
     explicit UiSweepOutputList(QWidget* parent = nullptr);
+    UiSweepOutputList(const UiSweepOutputList&) = delete;
+    UiSweepOutputList& operator=(const UiSweepOutputList&) = delete;
 
     /// @brief 绑定 SweepStudy，用于读写输出
     void setStudy(SweepStudy* study);
@@ -66,10 +68,10 @@ private:
         OUT_COUNT
     };
 
-    WeakPtr<SweepStudy> study_;
+    WeakPtr<SweepStudy> study_{};
 
-    QTableWidget* table_;
-    QPushButton*  addBtn_;
+    QTableWidget* table_{};
+    QPushButton*  addBtn_{};
     QPushButton*  removeBtn_;
 };
 

--- a/src/AstGUI/Analyzer/UiSweepOutputList.hpp
+++ b/src/AstGUI/Analyzer/UiSweepOutputList.hpp
@@ -72,7 +72,7 @@ private:
 
     QTableWidget* table_{};
     QPushButton*  addBtn_{};
-    QPushButton*  removeBtn_;
+    QPushButton*  removeBtn_{}; 
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Analyzer/UiSweepStudy.hpp
+++ b/src/AstGUI/Analyzer/UiSweepStudy.hpp
@@ -61,21 +61,21 @@ private:
     void setupUi();
     void rebuildCommandEditor();
 
-    WeakPtr<SweepStudy> analyzer_;
+    WeakPtr<SweepStudy> analyzer_{}; 
 
-    QTabWidget*        tabWidget_;
+    QTabWidget*        tabWidget_{}; 
 
     // 变量与输出 Tab（同页左右分栏）
-    QSplitter*           studySplitter_;
-    UiSweepVariableList* varList_;
-    UiSweepOutputList*   outputList_;
+    QSplitter*           studySplitter_{}; 
+    UiSweepVariableList* varList_{}; 
+    UiSweepOutputList*   outputList_{}; 
 
     // 任务模型 Tab
-    QStackedWidget*      commandStack_;
-    QLabel*              placeholderLabel_;
+    QStackedWidget*      commandStack_{}; 
+    QLabel*              placeholderLabel_{}; 
 
     // 执行按钮
-    QPushButton*         executeBtn_;
+    QPushButton*         executeBtn_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Analyzer/UiSweepStudy.hpp
+++ b/src/AstGUI/Analyzer/UiSweepStudy.hpp
@@ -42,6 +42,8 @@ class AST_GUI_API UiSweepStudy : public QWidget
     Q_OBJECT
 public:
     explicit UiSweepStudy(QWidget* parent = nullptr);
+    UiSweepStudy(const UiSweepStudy&) = delete;
+    UiSweepStudy& operator=(const UiSweepStudy&) = delete;
 
     /// @brief 绑定要编辑的 SweepStudy
     void setAnalyzer(SweepStudy* analyzer);

--- a/src/AstGUI/Analyzer/UiSweepVariableList.hpp
+++ b/src/AstGUI/Analyzer/UiSweepVariableList.hpp
@@ -71,11 +71,11 @@ private:
         VAR_COUNT
     };
 
-    WeakPtr<SweepStudy> study_;
+    WeakPtr<SweepStudy> study_{};
 
-    QTableWidget* table_;
-    QPushButton*  addBtn_;
-    QPushButton*  removeBtn_;
+    QTableWidget* table_{};
+    QPushButton*  addBtn_{};
+    QPushButton*  removeBtn_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Analyzer/UiSweepVariableList.hpp
+++ b/src/AstGUI/Analyzer/UiSweepVariableList.hpp
@@ -37,6 +37,8 @@ class AST_GUI_API UiSweepVariableList : public QWidget
     Q_OBJECT
 public:
     explicit UiSweepVariableList(QWidget* parent = nullptr);
+    UiSweepVariableList(const UiSweepVariableList&) = delete;
+    UiSweepVariableList& operator=(const UiSweepVariableList&) = delete;
 
     /// @brief 绑定 SweepStudy，用于读写变量
     void setStudy(SweepStudy* study);

--- a/src/AstGUI/Analyzer/UiWorkbenchExprPicker.hpp
+++ b/src/AstGUI/Analyzer/UiWorkbenchExprPicker.hpp
@@ -42,6 +42,9 @@ public:
     /// @param parent   父窗口
     explicit UiWorkbenchExprPicker(StudyWorkbench* workbench, QWidget* parent = nullptr);
 
+    UiWorkbenchExprPicker(const UiWorkbenchExprPicker&) = delete;
+    UiWorkbenchExprPicker& operator=(const UiWorkbenchExprPicker&) = delete;
+
     /// @brief 获取用户选中的表达式（Variable 即 Expr）
     Expr* selectedExpr() const { return selectedExpr_; }
 

--- a/src/AstGUI/Analyzer/UiWorkbenchExprPicker.hpp
+++ b/src/AstGUI/Analyzer/UiWorkbenchExprPicker.hpp
@@ -59,9 +59,9 @@ private:
     StudyWorkbench* workbench_;
     Expr*           selectedExpr_ = nullptr;
 
-    UiVariableList* inputList_;
-    UiVariableList* outputList_;
-    QPushButton*    advancedBtn_;
+    UiVariableList* inputList_{};
+    UiVariableList* outputList_{};
+    QPushButton*    advancedBtn_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Attribute/AttributeTree/UiAttributeTree.hpp
+++ b/src/AstGUI/Attribute/AttributeTree/UiAttributeTree.hpp
@@ -56,7 +56,7 @@ private:
     /// @brief 递归遍历继承链，收集所有属性
     void collectProperties(Class* type, std::vector<Property*>& out) const;
 
-    WeakPtr<Object> rootObject_;
+    WeakPtr<Object> rootObject_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Attribute/AttributeTree/UiAttributeTreeItem.hpp
+++ b/src/AstGUI/Attribute/AttributeTree/UiAttributeTreeItem.hpp
@@ -65,9 +65,9 @@ public:
     UiAttributeTreeItem* clone() const override;
 
 private:
-    Attribute   attr_;   ///< 对象-属性绑定器
-    std::string name_;   ///< 属性名缓存（Property::name()）
-    std::string desc_;   ///< 属性描述缓存（Property::desc()）
+    Attribute   attr_{};   ///< 对象-属性绑定器
+    std::string name_{};   ///< 属性名缓存（Property::name()）
+    std::string desc_{};   ///< 属性描述缓存（Property::desc()）
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/ForceModel/UiDragForce.hpp
+++ b/src/AstGUI/ForceModel/UiDragForce.hpp
@@ -44,6 +44,8 @@ public:
     UiDragForce(Object* object, QWidget *parent = nullptr);
     UiDragForce(QWidget *parent = nullptr);
     ~UiDragForce() = default;
+    UiDragForce(const UiDragForce&) = delete;
+    UiDragForce& operator=(const UiDragForce&) = delete;
 
     DragForce* getDragForce() const;
     void setDragForce(DragForce* drag);

--- a/src/AstGUI/ForceModel/UiGravityForce.hpp
+++ b/src/AstGUI/ForceModel/UiGravityForce.hpp
@@ -25,6 +25,8 @@ public:
     UiGravityForce(Object* object, QWidget *parent = nullptr);
     UiGravityForce(QWidget *parent = nullptr);
     ~UiGravityForce() = default;
+    UiGravityForce(const UiGravityForce&) = delete;
+    UiGravityForce& operator=(const UiGravityForce&) = delete;
 
     GravityForce* getGravityForce() const;
     void setGravityForce(GravityForce* gravity);

--- a/src/AstGUI/ForceModel/UiHPOPForceModel.hpp
+++ b/src/AstGUI/ForceModel/UiHPOPForceModel.hpp
@@ -54,6 +54,8 @@ class AST_GUI_API UiHPOPForceModel: public UiObject
 {
     Q_OBJECT
 public:
+    UiHPOPForceModel(const UiHPOPForceModel&) = delete;
+    UiHPOPForceModel& operator=(const UiHPOPForceModel&) = delete;
     UiHPOPForceModel(Object* object, QWidget *parent = nullptr);
     UiHPOPForceModel(QWidget *parent = nullptr);
     ~UiHPOPForceModel() = default;

--- a/src/AstGUI/ForceModel/UiHPOPForceModel.hpp
+++ b/src/AstGUI/ForceModel/UiHPOPForceModel.hpp
@@ -70,28 +70,28 @@ private slots:
     void applyTo(HPOPForceModel* hpop);
 private:
     // 布局
-    QVBoxLayout* mainLayout_;
-    QTabWidget* tabWidget_;
+    QVBoxLayout* mainLayout_{};
+    QTabWidget* tabWidget_{};
     
     // 引力模型标签页
-    QWidget* gravityTab_;
-    QVBoxLayout* gravityTabLayout_;
-    UiGravityForce* gravityWidget_;
+    QWidget* gravityTab_{};
+    QVBoxLayout* gravityTabLayout_{};
+    UiGravityForce* gravityWidget_{};
     
     // 三体引力配置
-    QWidget* thirdBodyTab_;
-    QVBoxLayout* thirdBodyTabLayout_;
-    UiThirdBodyForceList* thirdBodyWidget_;
+    QWidget* thirdBodyTab_{};
+    QVBoxLayout* thirdBodyTabLayout_{};
+    UiThirdBodyForceList* thirdBodyWidget_{};
     
     // 大气阻力标签页
-    QWidget* dragTab_;
-    QVBoxLayout* dragTabLayout_;
-    UiDragForce* dragWidget_;
+    QWidget* dragTab_{};
+    QVBoxLayout* dragTabLayout_{};
+    UiDragForce* dragWidget_{};
     
     // 太阳光压标签页
-    QWidget* srpTab_;
-    QVBoxLayout* srpTabLayout_;
-    UiSolarRadiationPressure* srpWidget_;
+    QWidget* srpTab_{};
+    QVBoxLayout* srpTabLayout_{};
+    UiSolarRadiationPressure* srpWidget_{};
     
 
 };

--- a/src/AstGUI/ForceModel/UiPointMassForce.hpp
+++ b/src/AstGUI/ForceModel/UiPointMassForce.hpp
@@ -20,6 +20,8 @@ public:
     UiPointMassForce(Object* object, QWidget *parent = nullptr);
     UiPointMassForce(QWidget *parent = nullptr);
     ~UiPointMassForce() = default;
+    UiPointMassForce(const UiPointMassForce&) = delete;
+    UiPointMassForce& operator=(const UiPointMassForce&) = delete;
 
     PointMassForce* getPointMassForce() const;
     void setPointMassForce(PointMassForce* pointMass);

--- a/src/AstGUI/ForceModel/UiSolarRadiationPressure.hpp
+++ b/src/AstGUI/ForceModel/UiSolarRadiationPressure.hpp
@@ -26,6 +26,8 @@ public:
     UiSolarRadiationPressure(Object* object, QWidget *parent = nullptr);
     UiSolarRadiationPressure(QWidget *parent = nullptr);
     ~UiSolarRadiationPressure() = default;
+    UiSolarRadiationPressure(const UiSolarRadiationPressure&) = delete;
+    UiSolarRadiationPressure& operator=(const UiSolarRadiationPressure&) = delete;
 
     SolarRadiationPressure* getSolarRadiationPressure() const;
     void setSolarRadiationPressure(SolarRadiationPressure* srp);

--- a/src/AstGUI/ForceModel/UiThirdBodyForce.hpp
+++ b/src/AstGUI/ForceModel/UiThirdBodyForce.hpp
@@ -28,6 +28,8 @@ public:
     UiThirdBodyForce(Object* object, QWidget *parent = nullptr);
     UiThirdBodyForce(QWidget *parent = nullptr);
     ~UiThirdBodyForce() = default;
+    UiThirdBodyForce(const UiThirdBodyForce&) = delete;
+    UiThirdBodyForce& operator=(const UiThirdBodyForce&) = delete;
 
     ThirdBodyForce* getThirdBodyForce() const;
     void setThirdBodyForce(ThirdBodyForce* thirdBody);

--- a/src/AstGUI/ForceModel/UiThirdBodyForceList.hpp
+++ b/src/AstGUI/ForceModel/UiThirdBodyForceList.hpp
@@ -28,6 +28,8 @@ public:
     UiThirdBodyForceList(Object* object, QWidget *parent = nullptr);
     UiThirdBodyForceList(QWidget *parent = nullptr);
     ~UiThirdBodyForceList() = default;
+    UiThirdBodyForceList(const UiThirdBodyForceList&) = delete;
+    UiThirdBodyForceList& operator=(const UiThirdBodyForceList&) = delete;
 
     HPOPForceModel* getHPOPForceModel() const;
     void setHPOPForceModel(HPOPForceModel* hpop);

--- a/src/AstGUI/Foundation/ObjectTree/UiObjectTree.hpp
+++ b/src/AstGUI/Foundation/ObjectTree/UiObjectTree.hpp
@@ -37,6 +37,9 @@ public:
 
     ~UiObjectTree() override;
 
+    UiObjectTree(const UiObjectTree&) = delete;
+    UiObjectTree& operator=(const UiObjectTree&) = delete;
+
     /// @brief 重建对象树，根据当前根节点设置确定显示范围
     void refresh();
 
@@ -75,7 +78,7 @@ signals:
     void objectDoubleClicked(Object* object);
 
 protected:
-    TreeBuildOptions buildOptions_; ///< 对象树构建选项
+    TreeBuildOptions buildOptions_{}; ///< 对象树构建选项
 
 private:
     UiObjectTreeItem* rootItem_ = nullptr;

--- a/src/AstGUI/Foundation/UiFilePath.hpp
+++ b/src/AstGUI/Foundation/UiFilePath.hpp
@@ -37,6 +37,8 @@ class AST_GUI_API UiFilePath: public QWidget
     Q_OBJECT
 
 public:
+    UiFilePath(const UiFilePath&) = delete;
+    UiFilePath& operator=(const UiFilePath&) = delete;
     UiFilePath(QWidget* parent = nullptr);
     
     /// @brief 设置文件路径
@@ -67,8 +69,8 @@ private slots:
     void onEditingFinished();
 private:
     UiValueEdit* lineEdit_{nullptr};
-    QString currentPath_;
-    QString filter_;
+    QString currentPath_{};
+    QString filter_{};
 };
 
 /*! @} */

--- a/src/AstGUI/Foundation/UiObject.hpp
+++ b/src/AstGUI/Foundation/UiObject.hpp
@@ -49,7 +49,7 @@ public:
     /// @param object 关联的对象指针
     void setObject(Object* object);
 private:
-    WeakPtr<Object> object_;
+    WeakPtr<Object> object_{};
 };
 
 

--- a/src/AstGUI/Foundation/UiQuantity.hpp
+++ b/src/AstGUI/Foundation/UiQuantity.hpp
@@ -43,6 +43,8 @@ class AST_GUI_API UiQuantity: public UiValueEdit
 
 public:
     explicit UiQuantity(QWidget* parent = nullptr);
+    UiQuantity(const UiQuantity&) = delete;
+    UiQuantity& operator=(const UiQuantity&) = delete;
 
     /// @brief 设置数量值
     /// @param quantity 数量值
@@ -125,7 +127,7 @@ private slots:
 private:
     void updateQuantity();
     void updateArrowIcon();
-    Quantity currentQuantity_;
+    Quantity currentQuantity_{};
     QAction* actionSwitchUnit_{nullptr};
     bool dimensionLocked_{true};
 };

--- a/src/AstGUI/Foundation/UiSelectFrame.hpp
+++ b/src/AstGUI/Foundation/UiSelectFrame.hpp
@@ -50,6 +50,8 @@ class AST_GUI_API UiSelectFrame : public QWidget
 public:
     explicit UiSelectFrame(QWidget* parent = nullptr);
     ~UiSelectFrame() override;
+    UiSelectFrame(const UiSelectFrame&) = delete;
+    UiSelectFrame& operator=(const UiSelectFrame&) = delete;
 
     Frame* getSelectedFrame();
     void setSelectedFrame(Frame* frame);

--- a/src/AstGUI/Foundation/UiTimeInterval.hpp
+++ b/src/AstGUI/Foundation/UiTimeInterval.hpp
@@ -40,6 +40,8 @@ class AST_GUI_API UiTimeInterval : public QWidget
 public:
     explicit UiTimeInterval(QWidget* parent = nullptr);
     ~UiTimeInterval() = default;
+    UiTimeInterval(const UiTimeInterval&) = delete;
+    UiTimeInterval& operator=(const UiTimeInterval&) = delete;
     
     /// @brief 设置时间区间
     /// @param timeInterval 时间区间

--- a/src/AstGUI/Math/UiODEIntegratorEditor.hpp
+++ b/src/AstGUI/Math/UiODEIntegratorEditor.hpp
@@ -39,6 +39,8 @@ class AST_GUI_API UiODEIntegratorEditor : public QWidget
 public:
     explicit UiODEIntegratorEditor(QWidget* parent = nullptr);
     ~UiODEIntegratorEditor() override;
+    UiODEIntegratorEditor(const UiODEIntegratorEditor&) = delete;
+    UiODEIntegratorEditor& operator=(const UiODEIntegratorEditor&) = delete;
 
     void setIntegrator(ODEIntegrator* integrator);
     ODEIntegrator* getIntegrator() const;

--- a/src/AstGUI/Math/UiODEVarStepIntegrator.hpp
+++ b/src/AstGUI/Math/UiODEVarStepIntegrator.hpp
@@ -31,6 +31,8 @@ public:
     UiODEVarStepIntegrator(Object* object, QWidget *parent = nullptr);
     UiODEVarStepIntegrator(QWidget *parent = nullptr);
     ~UiODEVarStepIntegrator() = default;
+    UiODEVarStepIntegrator(const UiODEVarStepIntegrator&) = delete;
+    UiODEVarStepIntegrator& operator=(const UiODEVarStepIntegrator&) = delete;
 
     ODEVarStepIntegrator* getODEVarStepIntegrator() const;
     void setODEVarStepIntegrator(ODEVarStepIntegrator* integrator);

--- a/src/AstGUI/Mission/UiCommandEditor.hpp
+++ b/src/AstGUI/Mission/UiCommandEditor.hpp
@@ -42,6 +42,8 @@ class AST_GUI_API UiCommandEditor : public QStackedWidget
 public:
     explicit UiCommandEditor(QWidget* parent = nullptr);
     ~UiCommandEditor() override;
+    UiCommandEditor(const UiCommandEditor&) = delete;
+    UiCommandEditor& operator=(const UiCommandEditor&) = delete;
 
     /// @brief 编辑指定命令 — 根据 RTTI 类型切换编辑器
     void editCommand(MissionCommand* cmd);

--- a/src/AstGUI/Mission/UiCommandSummary.hpp
+++ b/src/AstGUI/Mission/UiCommandSummary.hpp
@@ -47,9 +47,9 @@ struct SegmentContext
     const SpacecraftState*   outputState = nullptr;
     const State*             orbitState = nullptr;
     Frame*                   frame = nullptr;
-    CartState                cart;
-    ModOrbElem               moe;
-    TimePoint                stateEpoch;
+    CartState                cart{}; 
+    ModOrbElem               moe{}; 
+    TimePoint                stateEpoch{}; 
 
     /// @brief 上下文数据是否完整可用
     bool valid() const { return orbitState != nullptr; }

--- a/src/AstGUI/Mission/UiCommandSummary.hpp
+++ b/src/AstGUI/Mission/UiCommandSummary.hpp
@@ -85,6 +85,8 @@ public:
     explicit UiCommandSummary(Object* object, QWidget* parent = nullptr);
     explicit UiCommandSummary(QWidget* parent = nullptr);
     ~UiCommandSummary() override;
+    UiCommandSummary(const UiCommandSummary&) = delete;
+    UiCommandSummary& operator=(const UiCommandSummary&) = delete;
 
     /// @brief 设置要显示概要的命令
     void setCommand(Command* command);

--- a/src/AstGUI/Mission/UiExpressionBrowser.hpp
+++ b/src/AstGUI/Mission/UiExpressionBrowser.hpp
@@ -76,7 +76,7 @@ private:
     QPushButton*     propertySelectButton_ = nullptr;
     QPushButton*     calculationSelectButton_ = nullptr;
     WeakPtr<Object>  currentObject_ = nullptr;
-    SharedPtr<Expr>  selectedExpr_;
+    SharedPtr<Expr>  selectedExpr_{}; 
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Mission/UiExpressionBrowser.hpp
+++ b/src/AstGUI/Mission/UiExpressionBrowser.hpp
@@ -42,6 +42,8 @@ class AST_GUI_API UiExpressionBrowser : public QWidget
     Q_OBJECT
 public:
     explicit UiExpressionBrowser(QWidget* parent = nullptr);
+    UiExpressionBrowser(const UiExpressionBrowser&) = delete;
+    UiExpressionBrowser& operator=(const UiExpressionBrowser&) = delete;
 
     /// @brief 获取选中的表达式，无选中时返回 nullptr
     Expr* selectedExpression() const { return selectedExpr_.get(); }

--- a/src/AstGUI/Mission/UiFeasibleRegionStudy.hpp
+++ b/src/AstGUI/Mission/UiFeasibleRegionStudy.hpp
@@ -47,6 +47,8 @@ public:
     explicit UiFeasibleRegionStudy(Object* object, QWidget* parent = nullptr);
     explicit UiFeasibleRegionStudy(QWidget* parent = nullptr);
     ~UiFeasibleRegionStudy() override;
+    UiFeasibleRegionStudy(const UiFeasibleRegionStudy&) = delete;
+    UiFeasibleRegionStudy& operator=(const UiFeasibleRegionStudy&) = delete;
 
     void setStudy(FeasibleRegionStudy* study);
     FeasibleRegionStudy* getStudy() const;

--- a/src/AstGUI/Mission/UiInitialState.hpp
+++ b/src/AstGUI/Mission/UiInitialState.hpp
@@ -42,6 +42,8 @@ public:
     explicit UiInitialState(Object* object, QWidget* parent = nullptr);
     explicit UiInitialState(QWidget* parent = nullptr);
     ~UiInitialState() override;
+    UiInitialState(const UiInitialState&) = delete;
+    UiInitialState& operator=(const UiInitialState&) = delete;
 
     void setInitialState(InitialState* state);
     InitialState* getInitialState() const;

--- a/src/AstGUI/Mission/UiManeuver.hpp
+++ b/src/AstGUI/Mission/UiManeuver.hpp
@@ -37,6 +37,8 @@ public:
     explicit UiManeuver(Object* object, QWidget* parent = nullptr);
     explicit UiManeuver(QWidget* parent = nullptr);
     ~UiManeuver() override;
+    UiManeuver(const UiManeuver&) = delete;
+    UiManeuver& operator=(const UiManeuver&) = delete;
 
     void setManeuver(Maneuver* maneuver);
     Maneuver* getManeuver() const;

--- a/src/AstGUI/Mission/UiPropagate.hpp
+++ b/src/AstGUI/Mission/UiPropagate.hpp
@@ -42,6 +42,8 @@ public:
     explicit UiPropagate(Object* object, QWidget* parent = nullptr);
     explicit UiPropagate(QWidget* parent = nullptr);
     ~UiPropagate() override;
+    UiPropagate(const UiPropagate&) = delete;
+    UiPropagate& operator=(const UiPropagate&) = delete;
 
     void setPropagate(Propagate* prop);
     Propagate* getPropagate() const;

--- a/src/AstGUI/Mission/UiSequence.hpp
+++ b/src/AstGUI/Mission/UiSequence.hpp
@@ -38,6 +38,8 @@ public:
     explicit UiSequence(Object* object, QWidget* parent = nullptr);
     explicit UiSequence(QWidget* parent = nullptr);
     ~UiSequence() override;
+    UiSequence(const UiSequence&) = delete;
+    UiSequence& operator=(const UiSequence&) = delete;
 
     void setSequence(Sequence* seq);
     Sequence* getSequence() const;
@@ -59,6 +61,9 @@ public:
     explicit UiTargeterSequence(Object* object, QWidget* parent = nullptr);
     explicit UiTargeterSequence(QWidget* parent = nullptr);
     ~UiTargeterSequence() override;
+
+    UiTargeterSequence(const UiTargeterSequence&) = delete;
+    UiTargeterSequence& operator=(const UiTargeterSequence&) = delete;
 
     void setTargeterSequence(TargeterSequence* seq);
     TargeterSequence* getTargeterSequence() const;

--- a/src/AstGUI/Mission/UiSequenceWorkbench.hpp
+++ b/src/AstGUI/Mission/UiSequenceWorkbench.hpp
@@ -45,6 +45,8 @@ public:
     explicit UiSequenceWorkbench(QWidget* parent = nullptr);
     explicit UiSequenceWorkbench(Object* sequence, QWidget* parent = nullptr);
     ~UiSequenceWorkbench() override;
+    UiSequenceWorkbench(const UiSequenceWorkbench&) = delete;
+    UiSequenceWorkbench& operator=(const UiSequenceWorkbench&) = delete;
 
     /// @brief 设置外部 MainSequence（裸指针，不持有所有权）
     void setSequence(Sequence* sequence);

--- a/src/AstGUI/Mission/UiVariableList.hpp
+++ b/src/AstGUI/Mission/UiVariableList.hpp
@@ -39,6 +39,8 @@ class AST_GUI_API UiVariableList : public QWidget
     Q_OBJECT
 public:
     explicit UiVariableList(QWidget* parent = nullptr);
+    UiVariableList(const UiVariableList&) = delete;
+    UiVariableList& operator=(const UiVariableList&) = delete;
 
     /// @brief 设置要编辑的变量列表（裸指针，不持有所有权）
     /// @param variableList 要编辑的变量列表，被owner对象持有

--- a/src/AstGUI/Mission/UiVariableList.hpp
+++ b/src/AstGUI/Mission/UiVariableList.hpp
@@ -103,17 +103,17 @@ private:
     bool eventFilter(QObject* obj, QEvent* event) override;
     void syncOrderFromTable();
 
-    QVBoxLayout*    mainLayout_;
-    QTableWidget*   tableWidget_;
-    QHBoxLayout*    buttonLayout_;
-    QToolButton*    addButton_;
-    QToolButton*    removeButton_;
-    QToolButton*    refreshButton_;
+    QVBoxLayout*    mainLayout_{};
+    QTableWidget*   tableWidget_{};
+    QHBoxLayout*    buttonLayout_{};
+    QToolButton*    addButton_{};
+    QToolButton*    removeButton_{};
+    QToolButton*    refreshButton_{};
 private:
     VariableList*   variableList_ = nullptr;
-    WeakPtr<Object> variableListOwner_;
+    WeakPtr<Object> variableListOwner_{};
     Interpreter*    interpreter_ = nullptr;
-    WeakPtr<Object> interpreterOwner_;
+    WeakPtr<Object> interpreterOwner_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Motion/UiMotionTwoBody.hpp
+++ b/src/AstGUI/Motion/UiMotionTwoBody.hpp
@@ -52,6 +52,8 @@ public:
     UiMotionTwoBody(Object* object, QWidget *parent = nullptr);
     UiMotionTwoBody(QWidget *parent = nullptr);
     ~UiMotionTwoBody() = default;
+    UiMotionTwoBody(const UiMotionTwoBody&) = delete;
+    UiMotionTwoBody& operator=(const UiMotionTwoBody&) = delete;
 
     MotionTwoBody* getMotionTwoBody() const;
     void setMotionTwoBody(MotionTwoBody* motion);

--- a/src/AstGUI/Propagator/UiBurnEditor.hpp
+++ b/src/AstGUI/Propagator/UiBurnEditor.hpp
@@ -38,6 +38,8 @@ class AST_GUI_API UiBurnEditor : public QWidget
 public:
     explicit UiBurnEditor(QWidget* parent = nullptr);
     ~UiBurnEditor() override;
+    UiBurnEditor(const UiBurnEditor&) = delete;
+    UiBurnEditor& operator=(const UiBurnEditor&) = delete;
 
     void setBurn(Burn* burn);
     void clear();

--- a/src/AstGUI/Propagator/UiBurnImpulsive.hpp
+++ b/src/AstGUI/Propagator/UiBurnImpulsive.hpp
@@ -38,6 +38,8 @@ public:
     explicit UiBurnImpulsive(Object* object, QWidget* parent = nullptr);
     explicit UiBurnImpulsive(QWidget* parent = nullptr);
     ~UiBurnImpulsive() override = default;
+    UiBurnImpulsive(const UiBurnImpulsive&) = delete;
+    UiBurnImpulsive& operator=(const UiBurnImpulsive&) = delete;
 
     void setBurn(Burn* burn);
     BurnImpulsive* getBurnImpulsive() const;

--- a/src/AstGUI/Propagator/UiEventDetector.hpp
+++ b/src/AstGUI/Propagator/UiEventDetector.hpp
@@ -41,6 +41,8 @@ public:
     explicit UiEventDetector(Object* object, QWidget* parent = nullptr);
     explicit UiEventDetector(QWidget* parent = nullptr);
     ~UiEventDetector() override;
+    UiEventDetector(const UiEventDetector&) = delete;
+    UiEventDetector& operator=(const UiEventDetector&) = delete;
 
     void setEventDetector(EventDetector* det);
     EventDetector* getEventDetector() const;

--- a/src/AstGUI/Propagator/UiEventDetectorEditor.hpp
+++ b/src/AstGUI/Propagator/UiEventDetectorEditor.hpp
@@ -35,6 +35,8 @@ class AST_GUI_API UiEventDetectorEditor : public QStackedWidget
 public:
     explicit UiEventDetectorEditor(QWidget* parent = nullptr);
     ~UiEventDetectorEditor() override;
+    UiEventDetectorEditor(const UiEventDetectorEditor&) = delete;
+    UiEventDetectorEditor& operator=(const UiEventDetectorEditor&) = delete;
 
     void setDetector(EventDetector* det);
     EventDetector* getDetector() const;

--- a/src/AstGUI/SolarSystem/Ephemeris/UiBodyEphemerisDE.hpp
+++ b/src/AstGUI/SolarSystem/Ephemeris/UiBodyEphemerisDE.hpp
@@ -38,6 +38,8 @@ class AST_GUI_API UiBodyEphemerisDE: public UiObject
     Q_OBJECT
 public:
     explicit UiBodyEphemerisDE(Object* object, QWidget *parent = nullptr);
+    UiBodyEphemerisDE(const UiBodyEphemerisDE&) = delete;
+    UiBodyEphemerisDE& operator=(const UiBodyEphemerisDE&) = delete;
     explicit UiBodyEphemerisDE(QWidget *parent = nullptr);
     ~UiBodyEphemerisDE() = default;
 

--- a/src/AstGUI/SolarSystem/Ephemeris/UiBodyEphemerisSPK.hpp
+++ b/src/AstGUI/SolarSystem/Ephemeris/UiBodyEphemerisSPK.hpp
@@ -41,6 +41,8 @@ public:
     UiBodyEphemerisSPK(Object* object, QWidget *parent = nullptr);
     UiBodyEphemerisSPK(QWidget *parent = nullptr);
     ~UiBodyEphemerisSPK() = default;
+    UiBodyEphemerisSPK(const UiBodyEphemerisSPK&) = delete;
+    UiBodyEphemerisSPK& operator=(const UiBodyEphemerisSPK&) = delete;
 
     void refreshUi();
     void apply();

--- a/src/AstGUI/SolarSystem/UiCelestialBody.hpp
+++ b/src/AstGUI/SolarSystem/UiCelestialBody.hpp
@@ -29,6 +29,8 @@ public:
     UiCelestialBody(Object* object, QWidget* parent = nullptr);
     UiCelestialBody(QWidget* parent = nullptr);
     ~UiCelestialBody() = default;
+    UiCelestialBody(const UiCelestialBody&) = delete;
+    UiCelestialBody& operator=(const UiCelestialBody&) = delete;
 
     void refreshUi();
     void apply();

--- a/src/AstGUI/Spacecraft/UiEventDetectorList.hpp
+++ b/src/AstGUI/Spacecraft/UiEventDetectorList.hpp
@@ -41,6 +41,8 @@ public:
     explicit UiEventDetectorList(Object* object, QWidget* parent = nullptr);
     explicit UiEventDetectorList(QWidget* parent = nullptr);
     ~UiEventDetectorList() override;
+    UiEventDetectorList(const UiEventDetectorList&) = delete;
+    UiEventDetectorList& operator=(const UiEventDetectorList&) = delete;
 
     void setPropagate(Propagate* prop);
     Propagate* getPropagate() const;

--- a/src/AstGUI/Spacecraft/UiFuelTank.hpp
+++ b/src/AstGUI/Spacecraft/UiFuelTank.hpp
@@ -37,6 +37,8 @@ public:
     explicit UiFuelTank(Object* object, QWidget* parent = nullptr);
     explicit UiFuelTank(QWidget* parent = nullptr);
     ~UiFuelTank() override;
+    UiFuelTank(const UiFuelTank&) = delete;
+    UiFuelTank& operator=(const UiFuelTank&) = delete;
 
     void setSpacecraftState(SpacecraftState* state);
     SpacecraftState* getSpacecraftState() const;

--- a/src/AstGUI/Spacecraft/UiSpacecraftParams.hpp
+++ b/src/AstGUI/Spacecraft/UiSpacecraftParams.hpp
@@ -37,6 +37,8 @@ public:
     explicit UiSpacecraftParams(Object* object, QWidget* parent = nullptr);
     explicit UiSpacecraftParams(QWidget* parent = nullptr);
     ~UiSpacecraftParams() override;
+    UiSpacecraftParams(const UiSpacecraftParams&) = delete;
+    UiSpacecraftParams& operator=(const UiSpacecraftParams&) = delete;
 
     void setSpacecraftState(SpacecraftState* state);
     SpacecraftState* getSpacecraftState() const;

--- a/src/AstGUI/State/UiStateCartesian.hpp
+++ b/src/AstGUI/State/UiStateCartesian.hpp
@@ -45,6 +45,8 @@ public:
     explicit UiStateCartesian(Object* object, QWidget *parent = nullptr);
     explicit UiStateCartesian(QWidget *parent = nullptr);
     ~UiStateCartesian() = default;
+    UiStateCartesian(const UiStateCartesian&) = delete;
+    UiStateCartesian& operator=(const UiStateCartesian&) = delete;
 
     void refreshUi();
     void apply();

--- a/src/AstGUI/State/UiStateEditor.hpp
+++ b/src/AstGUI/State/UiStateEditor.hpp
@@ -45,6 +45,8 @@ class AST_GUI_API UiStateEditor : public QWidget
 public:
     explicit UiStateEditor(QWidget* parent = nullptr);
     ~UiStateEditor() override;
+    UiStateEditor(const UiStateEditor&) = delete;
+    UiStateEditor& operator=(const UiStateEditor&) = delete;
 
     /// @brief 设置要编辑的 State，根据 RTTI 类型切换子编辑器
     void setState(State* state);

--- a/src/AstGUI/State/UiStateKeplerian.hpp
+++ b/src/AstGUI/State/UiStateKeplerian.hpp
@@ -48,6 +48,8 @@ public:
     explicit UiStateKeplerian(Object* object, QWidget *parent = nullptr);
     explicit UiStateKeplerian(QWidget *parent = nullptr);
     ~UiStateKeplerian() = default;
+    UiStateKeplerian(const UiStateKeplerian&) = delete;
+    UiStateKeplerian& operator=(const UiStateKeplerian&) = delete;
 
     StateKeplerian* getStateKeplerian() const;
     void setStateKeplerian(StateKeplerian* state);

--- a/src/AstGUI/Window/UiMainWindow.hpp
+++ b/src/AstGUI/Window/UiMainWindow.hpp
@@ -46,6 +46,8 @@ class UiMainWindow : public QMainWindow
 public:
     explicit UiMainWindow(QWidget *parent = nullptr);
     ~UiMainWindow();
+    UiMainWindow(const UiMainWindow&) = delete;
+    UiMainWindow& operator=(const UiMainWindow&) = delete;
 
 private:
     void setupUi();

--- a/src/AstGUI/Window/UiNewObjectDialog.hpp
+++ b/src/AstGUI/Window/UiNewObjectDialog.hpp
@@ -44,6 +44,8 @@ class AST_GUI_API UiNewObjectDialog : public QDialog
 public:
     explicit UiNewObjectDialog(QWidget* parent = nullptr);
     ~UiNewObjectDialog() override;
+    UiNewObjectDialog(const UiNewObjectDialog&) = delete;
+    UiNewObjectDialog& operator=(const UiNewObjectDialog&) = delete;
 
     /// @brief 获取用户选择的类型名
     QString selectedTypeName() const;

--- a/src/AstGUI/Window/UiNewObjectDialog.hpp
+++ b/src/AstGUI/Window/UiNewObjectDialog.hpp
@@ -61,13 +61,13 @@ private:
 
     struct ClassInfo
     {
-        std::string name;
-        std::string desc;
-        Class*      cls;
+        std::string name{}; 
+        std::string desc{}; 
+        Class*      cls{}; 
     };
 
-    std::vector<ClassInfo> allClasses_;   ///< 全部可创建的类型（未过滤）
-    mutable QString         generatedName_; ///< 自动生成的对象名（延迟计算，故为 mutable）
+    std::vector<ClassInfo> allClasses_{}; ///< 全部可创建的类型（未过滤）
+    mutable QString         generatedName_{}; ///< 自动生成的对象名（延迟计算，故为 mutable）
 
     QLineEdit*   searchEdit_ = nullptr;
     QListWidget* typeList_ = nullptr;

--- a/src/AstGUI/Window/UiNewObjectQuickDialog.hpp
+++ b/src/AstGUI/Window/UiNewObjectQuickDialog.hpp
@@ -57,6 +57,8 @@ class AST_GUI_API UiNewObjectQuickDialog : public QDialog
 public:
     explicit UiNewObjectQuickDialog(QWidget* parent = nullptr);
     ~UiNewObjectQuickDialog() override;
+    UiNewObjectQuickDialog(const UiNewObjectQuickDialog&) = delete;
+    UiNewObjectQuickDialog& operator=(const UiNewObjectQuickDialog&) = delete;
 
     /// @brief 获取创建成功后的对象显示名称（用于状态栏提示）
     QString createdObjectName() const;

--- a/src/AstGUI/Window/UiNewObjectQuickDialog.hpp
+++ b/src/AstGUI/Window/UiNewObjectQuickDialog.hpp
@@ -103,7 +103,7 @@ private:
     // 状态
     int           selectedEntry_ = -1;
     Object*       selectedParent_ = nullptr;
-    QString       createdObjectName_;
+    QString       createdObjectName_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstGUI/Window/UiOrbitWizard.hpp
+++ b/src/AstGUI/Window/UiOrbitWizard.hpp
@@ -43,6 +43,8 @@ class AST_GUI_API UiOrbitWizard : public QDialog
 public:
     explicit UiOrbitWizard(QWidget *parent = nullptr);
     ~UiOrbitWizard();
+    UiOrbitWizard(const UiOrbitWizard&) = delete;
+    UiOrbitWizard& operator=(const UiOrbitWizard&) = delete;
 
 private:
     void setupUi();

--- a/src/AstGfx/AstGfxAPI.hpp
+++ b/src/AstGfx/AstGfxAPI.hpp
@@ -60,15 +60,17 @@ public:
 private:
     /// @brief 构造函数（私有，单例模式）
     AstGfxAPI();
-    
+    AstGfxAPI(const AstGfxAPI&) = delete;
+    AstGfxAPI& operator=(const AstGfxAPI&) = delete;
+
     /// @brief 析构函数（私有，单例模式）
     ~AstGfxAPI();
     
     /// @brief 主可视化系统
-    GfxMain* m_gfxMain;
+    GfxMain* m_gfxMain{};
     
     /// @brief 太阳系可视化系统
-    GfxSolarSystem* m_solarSystem;
+    GfxSolarSystem* m_solarSystem{};
 };
 
 /// @brief 初始化可视化系统

--- a/src/AstGfx/GfxCelestialBody.hpp
+++ b/src/AstGfx/GfxCelestialBody.hpp
@@ -51,7 +51,9 @@ public:
     /// @param radius 天体半径
     /// @param color 天体颜色
     GfxCelestialBody(const std::string& name, double radius, const osg::Vec4& color = osg::Vec4(1.0f, 1.0f, 1.0f, 1.0f));
-    
+    GfxCelestialBody(const GfxCelestialBody&) = delete;
+    GfxCelestialBody& operator=(const GfxCelestialBody&) = delete;
+
     /// @brief 析构函数
     ~GfxCelestialBody();
     
@@ -145,16 +147,16 @@ private:
     double m_currentOrbit;
     
     /// @brief 天体的位置姿态变换节点
-    osg::PositionAttitudeTransform* m_pat;
-    
+    osg::PositionAttitudeTransform* m_pat{};
+
     /// @brief 天体的形状节点
-    osg::ShapeDrawable* m_shapeDrawable;
-    
+    osg::ShapeDrawable* m_shapeDrawable{};
+
     /// @brief 天体的材质
-    osg::Material* m_material;
-    
+    osg::Material* m_material{};
+
     /// @brief 天体的纹理
-    osg::Texture2D* m_texture;
+    osg::Texture2D* m_texture{};
     
     /// @brief 创建天体模型
     bool createModel();

--- a/src/AstGfx/GfxMain.hpp
+++ b/src/AstGfx/GfxMain.hpp
@@ -40,7 +40,9 @@ class GfxMain {
 public:
     /// @brief 构造函数
     GfxMain();
-    
+    GfxMain(const GfxMain&) = delete;
+    GfxMain& operator=(const GfxMain&) = delete;
+
     /// @brief 析构函数
     ~GfxMain();
     
@@ -67,10 +69,10 @@ public:
     
 private:
     /// @brief OSG查看器
-    osgViewer::Viewer* m_viewer;
+    osgViewer::Viewer* m_viewer{};
     
     /// @brief 场景根节点
-    osg::Group* m_root;
+    osg::Group* m_root{};
     
     /// @brief 初始化场景
     bool initScene();

--- a/src/AstGfx/GfxSolarSystem.hpp
+++ b/src/AstGfx/GfxSolarSystem.hpp
@@ -40,7 +40,9 @@ class AST_GFX_API GfxSolarSystem {
 public:
     /// @brief 构造函数
     GfxSolarSystem();
-    
+    GfxSolarSystem(const GfxSolarSystem&) = delete;
+    GfxSolarSystem& operator=(const GfxSolarSystem&) = delete;
+
     /// @brief 析构函数
     ~GfxSolarSystem();
     
@@ -82,13 +84,13 @@ public:
     
 private:
     /// @brief 太阳系根节点
-    osg::Group* m_root;
+    osg::Group* m_root{};
     
     /// @brief 天体列表
-    std::vector<GfxCelestialBody*> m_celestialBodies;
+    std::vector<GfxCelestialBody*> m_celestialBodies{};
     
     /// @brief 轨道线列表
-    std::vector<osg::Node*> m_orbitLines;
+    std::vector<osg::Node*> m_orbitLines{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstLoader/Common/LoaderContext.hpp
+++ b/src/AstLoader/Common/LoaderContext.hpp
@@ -36,8 +36,8 @@ class LoaderContext
 {
 public:
     LoaderContext* parent_{nullptr};        ///< 父上下文
-    std::string scenarioDir_;               ///< 场景目录
-    std::string filepath_;                  ///< 文件路径
+    std::string scenarioDir_{};               ///< 场景目录
+    std::string filepath_{};                  ///< 文件路径
 };
 
 

--- a/src/AstLoader/Core/Mission/ValXMLLoader.cpp
+++ b/src/AstLoader/Core/Mission/ValXMLLoader.cpp
@@ -38,10 +38,10 @@ AST_NAMESPACE_BEGIN
 namespace{
 
 struct ParseContext{
-    std::string name_;
-    std::string class_;
-    std::string text_;
-    SharedPtr<Value> value_;
+    std::string name_{};
+    std::string class_{};
+    std::string text_{};
+    SharedPtr<Value> value_{};
 };
 
 class ValXMLSaxBase: public XMLSax

--- a/src/AstLoader/Core/Mission/ValXMLLoader.cpp
+++ b/src/AstLoader/Core/Mission/ValXMLLoader.cpp
@@ -103,8 +103,8 @@ protected:
     }
 protected:
     size_t currentDepth_{0};                ///< 当前解析深度，1表示根元素
-    std::vector<ParseContext> stack_;       ///< 解析上下文栈
-    SharedPtr<Value> value_;                ///< 当前解析到的值
+    std::vector<ParseContext> stack_{};      ///< 解析上下文栈
+    SharedPtr<Value> value_{};               ///< 当前解析到的值
 };
 
 class ValXMLSax: public ValXMLSaxBase

--- a/src/AstLoader/Sim/BasicComponentLoader.hpp
+++ b/src/AstLoader/Sim/BasicComponentLoader.hpp
@@ -36,7 +36,7 @@ AST_NAMESPACE_BEGIN
 
 struct VehiclePathData
 {
-    SharedPtr<CelestialBody> centralBody_;
+    SharedPtr<CelestialBody> centralBody_{};
     bool storeEphemeris_ = false;
     bool smoothInterp_ = false;
 };

--- a/src/AstLoader/Sim/MotionHPOPSax.hpp
+++ b/src/AstLoader/Sim/MotionHPOPSax.hpp
@@ -54,19 +54,19 @@ protected:
 private:
     CartState cartState_{};                ///< 直角坐标
     HPOPForceModel forceModel_{};          ///< 力模型
-    PhysicalParam spacecraftParam_;
+    PhysicalParam spacecraftParam_{}; 
     struct {
-        std::string method_;               ///< 积分器方法 (IntegMethod)
-        std::string stepControlMethod_;    ///< 步长控制方法 (StepControlMethod)
+        std::string method_{};              ///< 积分器方法 (IntegMethod)
+        std::string stepControlMethod_{};   ///< 步长控制方法 (StepControlMethod)
         double errorTolerance_ = 1e-13;    ///< 误差容限 (ErrorTolerance)
         double timeStep_ = 60.0;           ///< 时间步长 (TimeStep)
         double minStepSize_ = 1.0;         ///< 最小步长 (MinStepSize)
         double maxStepSize_ = 86400.0;     ///< 最大步长 (MaxStepSize)
         bool reportOnFixedStep_ = true;    ///< 按固定步长报告 (ReportOnFixedStep)
         int interpolationSamplesM1_ = 7;   ///< 插值采样数-1 (InterpolationSamplesM1)
-        std::string interpolationMethod_;  ///< 插值方法 (InterpolationMethod)
+        std::string interpolationMethod_{}; ///< 插值方法 (InterpolationMethod)
         double altitudeCutOff_ = 10000.0;  ///< 高度截止 (AltitudeCutOff)
-    } integrator_;                      ///< 积分器配置参数
+    } integrator_{};                      ///< 积分器配置参数
 };
 
 /*! @} */

--- a/src/AstLoader/Sim/MotionOrbitDynamicsKeplerianSax.hpp
+++ b/src/AstLoader/Sim/MotionOrbitDynamicsKeplerianSax.hpp
@@ -47,13 +47,13 @@ protected:
     double rightAscension_ = 0.0;
     double trueAnomaly_ = 0.0;
     double timeStep_ = 0.0;
-    std::string orbElemCoordSys_;
-    SharedPtr<Axes> orbElemCoordAxes_;
-    std::string propagationCoordSys_;
-    SharedPtr<Axes> propagationCoordAxes_;
+    std::string orbElemCoordSys_{};
+    SharedPtr<Axes> orbElemCoordAxes_{};
+    std::string propagationCoordSys_{};
+    SharedPtr<Axes> propagationCoordAxes_{};
     int displayCoordType_ = 0;
-    std::string displayCoordSys_;
-    SharedPtr<Axes> displayCoordAxes_;
+    std::string displayCoordSys_{};
+    SharedPtr<Axes> displayCoordAxes_{};
 };
 
 

--- a/src/AstLoader/Sim/MotionOrbitDynamicsSax.hpp
+++ b/src/AstLoader/Sim/MotionOrbitDynamicsSax.hpp
@@ -59,11 +59,11 @@ protected:
 protected:
     BKVParser& parser_;
     const VehiclePathData& vehiclePathData_;
-    SharedPtr<EventTime> ephemSmartEpoch_;
-    SharedPtr<EventInterval> ephemSmartInterval_;
-    TimePoint ephemEpoch_;
-    TimePoint startTime_;
-    TimePoint stopTime_;
+    SharedPtr<EventTime> ephemSmartEpoch_{};
+    SharedPtr<EventInterval> ephemSmartInterval_{};
+    TimePoint ephemEpoch_{};
+    TimePoint startTime_{};
+    TimePoint stopTime_{};
     bool useScenTime_ = false;
 };
 

--- a/src/AstLoader/Sim/MoverLoader.cpp
+++ b/src/AstLoader/Sim/MoverLoader.cpp
@@ -71,11 +71,11 @@ errc_t _aLoadJ4Perturbation(BKVParser& parser, const VehiclePathData& VehiclePat
 errc_t _aLoadSGP4(BKVParser& parser, const VehiclePathData& vehiclePathData, ScopedPtr<MotionProfile>& motionProfile)
 {
     struct {
-        std::string SSCNumber_;
-        std::string intlDesignator_;
-        std::string commonName_;
-        std::vector<TwoLineElement> elements_;
-        SharedPtr<EventInterval> interval_;
+        std::string SSCNumber_{};
+        std::string intlDesignator_{};
+        std::string commonName_{};
+        std::vector<TwoLineElement> elements_{};
+        SharedPtr<EventInterval> interval_{};
         double timeStep_ = 0.0;
         TimePoint startTime_{};
         TimePoint stopTime_{};

--- a/src/AstLoader/Sim/MoverLoader.cpp
+++ b/src/AstLoader/Sim/MoverLoader.cpp
@@ -214,7 +214,7 @@ errc_t _aLoadHPOP(BKVParser& parser, const VehiclePathData& vehiclePathData, Sco
 errc_t _aLoadSPICE(BKVParser& parser, const VehiclePathData& vehiclePathData, ScopedPtr<MotionProfile>& motionProfile)
 {
     struct {
-        std::string filename_;
+        std::string filename_{};
         int satelliteID_{-1};
         int segmentNumber_{1};
         double stepSize_{60.0};
@@ -223,7 +223,7 @@ errc_t _aLoadSPICE(BKVParser& parser, const VehiclePathData& vehiclePathData, Sc
         bool use3rdOrderDelay_{false};
         TimePoint startTime_{};
         TimePoint stopTime_{};
-        SharedPtr<EventInterval> ephemSmartInterval_;
+        SharedPtr<EventInterval> ephemSmartInterval_{};
     } data;
 
 
@@ -305,8 +305,8 @@ errc_t _aLoadSPICE(BKVParser& parser, const VehiclePathData& vehiclePathData, Sc
 errc_t _aLoadBallistic(BKVParser& parser, const VehiclePathData& vehiclePathData, ScopedPtr<MotionProfile>& motionProfile)
 {
     struct {
-        TimePoint launchTime_;
-        TimePoint impactTime_;
+        TimePoint launchTime_{};
+        TimePoint impactTime_{};
         double launchLatitude_{0.0};
         double launchLongitude_{0.0};
         double launchAltitude_{0.0};
@@ -408,9 +408,9 @@ errc_t _aLoadBallistic(BKVParser& parser, const VehiclePathData& vehiclePathData
 errc_t _aLoadSimpleAscent(BKVParser& parser, const VehiclePathData& vehiclePathData, ScopedPtr<MotionProfile>& motionProfile)
 {
     struct {
-        TimePoint launchTime_;
+        TimePoint launchTime_{};
         bool useScenTime_{false};
-        TimePoint burnoutTime_;
+        TimePoint burnoutTime_{};
         double launchLatitude_{0.0};
         double launchLongitude_{0.0};
         double launchAltitude_{0.0};
@@ -501,18 +501,18 @@ errc_t _aLoadGreatArc(BKVParser& parser, const VehiclePathData& vehiclePathData,
 {
     struct {
         int versionIndicator_{0};
-        std::string method_;
+        std::string method_{};
         TimePoint timeOfFirstWaypoint_{};
         bool useScenTime_{false};
         double arcGranularity_{0.0};
         double defaultRate_{0.0};
         double defaultAltitude_{0.0};
         double defaultTurnRadius_{0.0};
-        std::string altRef_;
-        std::string altInterpMethod_;
+        std::string altRef_{};
+        std::string altInterpMethod_{};
         int numberOfWaypoints_{0};
-        std::vector<WayPoint> waypoints_;
-        SharedPtr<EventInterval> arcSmartInterval_;
+        std::vector<WayPoint> waypoints_{};
+        SharedPtr<EventInterval> arcSmartInterval_{};
     } data;
 
     while(1)
@@ -605,7 +605,7 @@ errc_t _aLoadExternExternalEphemeris(BKVParser& parser, const VehiclePathData& V
     BKVItemView item;
     BKVParser::EToken token;
     struct {
-        std::string filename_;
+        std::string filename_{};
     } data;
     do{
         token = parser.getNext(item);

--- a/src/AstMath/Array/Vector.cpp
+++ b/src/AstMath/Array/Vector.cpp
@@ -20,7 +20,14 @@
 
 #include "Vector.hpp"
 #ifdef AST_WITH_FMT
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#endif
 #include <fmt/format.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 AST_NAMESPACE_BEGIN

--- a/src/AstMath/Array/Vector.hpp
+++ b/src/AstMath/Array/Vector.hpp
@@ -121,6 +121,10 @@ class VectorX
 public:
     VectorX();
     VectorX(size_t size);
+
+    VectorX(const VectorX&) = delete;
+    VectorX& operator=(const VectorX&) = delete;
+
     ~VectorX();
 
     void resize(size_t size);

--- a/src/AstMath/Attitude/AngleAxis.hpp
+++ b/src/AstMath/Attitude/AngleAxis.hpp
@@ -35,7 +35,7 @@ class AngleAxis
 {
 public:
     /// @brief 轴角类默认构造函数，这里不进行任何初始化，也不初始化为0
-    AngleAxis(){};
+    AngleAxis() : axis_(), angle_() {};
 
     /// @brief 轴角类构造函数
     /// @param axis 旋转轴

--- a/src/AstMath/Attitude/AngleAxis.hpp
+++ b/src/AstMath/Attitude/AngleAxis.hpp
@@ -34,7 +34,7 @@ AST_NAMESPACE_BEGIN
 class AngleAxis
 {
 public:
-    /// @brief 轴角类默认构造函数，这里不进行任何初始化，也不初始化为0
+    /// @brief 轴角类默认构造函数，对成员进行值初始化（基础类型初始化为0）
     AngleAxis() : axis_(), angle_() {};
 
     /// @brief 轴角类构造函数

--- a/src/AstMath/Interpolator/LagrangeInterpolator.hpp
+++ b/src/AstMath/Interpolator/LagrangeInterpolator.hpp
@@ -84,6 +84,8 @@ public:
 
     /// @brief 析构函数
     ~LagrangeInterpolator() override;
+    LagrangeInterpolator(const LagrangeInterpolator&) = delete;
+    LagrangeInterpolator& operator=(const LagrangeInterpolator&) = delete;
 
     /// @brief 计算插值结果
     /// @param x 输入值

--- a/src/AstMath/ODE/ODEFixedStepIntegrator.cpp
+++ b/src/AstMath/ODE/ODEFixedStepIntegrator.cpp
@@ -111,7 +111,7 @@ ODEFixedStepIntegrator::Workspace::~Workspace()
 }
 
 ODEFixedStepIntegrator::ODEFixedStepIntegrator()
-    : stepSize_(60)
+    : workspace_(), stepSize_(60)
 {
 
 }

--- a/src/AstMath/ODE/ODEFixedStepIntegrator.hpp
+++ b/src/AstMath/ODE/ODEFixedStepIntegrator.hpp
@@ -67,6 +67,10 @@ public:
     {
     public:
         Workspace();
+
+        Workspace(const Workspace&) = delete;
+        Workspace& operator=(const Workspace&) = delete;
+
         ~Workspace();
         void reset(int dimension, int stage);
         void clear();

--- a/src/AstMath/ODE/ODEIntegrator.hpp
+++ b/src/AstMath/ODE/ODEIntegrator.hpp
@@ -211,8 +211,8 @@ protected:
 protected:
     ODE* ode_{nullptr};                                     ///< ODE方程
     ODEStateObserver* workStateObserver_{nullptr};          ///< 状态观察者
-    ODEEventDetectorList eventDetectorList_;                ///< 事件检测器列表
-    ODEStateObserverList stateObserverList_;                ///< 状态观察者列表
+    ODEEventDetectorList eventDetectorList_{};               ///< 事件检测器列表
+    ODEStateObserverList stateObserverList_{};               ///< 状态观察者列表
     ODEInnerStateObserver* innerStateObserver_{nullptr};    ///< 内部状态观察者
     double* stateAtStepStart_{nullptr};                     ///< 当前积分步的开始状态
     double* stateAtStepEnd_{nullptr};                       ///< 当前积分步的结束状态

--- a/src/AstMath/ODE/ODEIntegrator.hpp
+++ b/src/AstMath/ODE/ODEIntegrator.hpp
@@ -40,7 +40,10 @@ class ODEEventDetector;
 class AST_MATH_API IODEIntegrator: public ObjectNamed
 {
 public:
+    IODEIntegrator() = default;
     virtual ~IODEIntegrator() {};
+    IODEIntegrator(const IODEIntegrator&) = delete;
+    IODEIntegrator& operator=(const IODEIntegrator&) = delete;
 
     /// @brief 初始化积分器
     /// @details 初始化积分器，设置ODE的维度和步长等参数

--- a/src/AstMath/ODE/StateObserver/ODEEventDetectorList.hpp
+++ b/src/AstMath/ODE/StateObserver/ODEEventDetectorList.hpp
@@ -49,7 +49,7 @@ public:
     ODEEventObserver& operator[](size_t index) { return *eventObservers_[index]; }
     const ODEEventObserver& operator[](size_t index) const { return *eventObservers_[index]; }
 protected:
-    std::vector<ODEEventObserver*> eventObservers_;
+    std::vector<ODEEventObserver*> eventObservers_{};
 };
 
 

--- a/src/AstMath/ODE/StateObserver/ODEEventObserver.hpp
+++ b/src/AstMath/ODE/StateObserver/ODEEventObserver.hpp
@@ -32,6 +32,8 @@ class AST_MATH_API ODEEventObserver: public ODEStateObserver
 {
 public:
     ODEEventObserver() = default;
+    ODEEventObserver(const ODEEventObserver&) = delete;
+    ODEEventObserver& operator=(const ODEEventObserver&) = delete;
     explicit ODEEventObserver(ODEEventDetector* detector);
     ~ODEEventObserver() override;
     EODEAction onStateUpdate(double* y, double& x, ODEIntegrator* integrator) final;

--- a/src/AstMath/ODE/StateObserver/ODEInnerStateObserver.hpp
+++ b/src/AstMath/ODE/StateObserver/ODEInnerStateObserver.hpp
@@ -30,8 +30,10 @@ class ODEIntegrator;
 class AST_MATH_API ODEInnerStateObserver : public ODEStateObserver
 {
 public:
-    explicit ODEInnerStateObserver(ODEIntegrator* integrator) 
+    explicit ODEInnerStateObserver(ODEIntegrator* integrator)
         : integrator_(integrator) {}
+    ODEInnerStateObserver(const ODEInnerStateObserver&) = delete;
+    ODEInnerStateObserver& operator=(const ODEInnerStateObserver&) = delete;
     ~ODEInnerStateObserver() = default;
     EODEAction onStateUpdate(double* y, double& x, ODEIntegrator* integrator) final;
 protected:

--- a/src/AstMath/ODE/StateObserver/ODEStateObserverList.hpp
+++ b/src/AstMath/ODE/StateObserver/ODEStateObserverList.hpp
@@ -46,7 +46,7 @@ public:
     ODEStateObserver& operator[](size_t index) { return *observers_[index]; }
     const ODEStateObserver& operator[](size_t index) const { return *observers_[index]; }
 protected:
-    std::vector<ODEStateObserver*> observers_;
+    std::vector<ODEStateObserver*> observers_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstMath/ODE/StateObserver/ODEStateVectorCollector.cpp
+++ b/src/AstMath/ODE/StateObserver/ODEStateVectorCollector.cpp
@@ -23,7 +23,7 @@
 AST_NAMESPACE_BEGIN
 
 ODEStateVectorCollector::ODEStateVectorCollector(int ndim)
-    : ndim_(ndim)
+    : ndim_(ndim), x_(), y_()
 {
     // x_.reserve(1024);
     // y_.reserve(1024);

--- a/src/AstMath/Transform/KinematicRotation.hpp
+++ b/src/AstMath/Transform/KinematicRotation.hpp
@@ -122,7 +122,7 @@ public:
     /// @param velocityOut 变换后的速度
     void transformVectorVelocityInv(const Vector3d& vector, const Vector3d& velocity, Vector3d& vectorOut, Vector3d& velocityOut) const;
 protected:
-    Vector3d angvel_;       ///< 角速度
+    Vector3d angvel_{};       ///< 角速度
 };
 
 A_ALWAYS_INLINE KinematicRotation KinematicRotation::Identity()

--- a/src/AstMath/Transform/KinematicTransform.hpp
+++ b/src/AstMath/Transform/KinematicTransform.hpp
@@ -143,8 +143,8 @@ private:
     KinematicRotation& kinematicRotation() { return reinterpret_cast<KinematicRotation&>(rotation_); }
     const KinematicRotation& kinematicRotation() const { return reinterpret_cast<const KinematicRotation&>(rotation_); }
 protected:
-    Vector3d angvel_;
-    Vector3d velocity_;
+    Vector3d angvel_{};
+    Vector3d velocity_{};
 };
 
 A_ALWAYS_INLINE KinematicTransform KinematicTransform::Identity()

--- a/src/AstMath/Transform/Rotation.hpp
+++ b/src/AstMath/Transform/Rotation.hpp
@@ -188,7 +188,7 @@ public:
     Vector3d transformVectorInv(const Vector3d& vector) const;
 
 protected:
-    Matrix3d matrix_;
+    Matrix3d matrix_{};
 };
 
 

--- a/src/AstMath/Transform/Transform.hpp
+++ b/src/AstMath/Transform/Transform.hpp
@@ -111,8 +111,8 @@ public:
     Vector3d transformPosition(const Vector3d& position) const;
 
 protected:
-    Vector3d translation_;  ///< 平移
-    Rotation rotation_;     ///< 旋转
+    Vector3d translation_{};  ///< 平移
+    Rotation rotation_{};     ///< 旋转
 };
 
 A_ALWAYS_INLINE Transform::Transform(const Vector3d &trans, const Rotation &rot)

--- a/src/AstMath/Util/Util.cpp
+++ b/src/AstMath/Util/Util.cpp
@@ -22,8 +22,15 @@
 #include <cmath>
 #include <utility>
 #ifdef AST_WITH_FMT
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#endif
 #include <fmt/core.h>
 #include <fmt/format.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 AST_NAMESPACE_BEGIN

--- a/src/AstMock/MockBuffer.cpp
+++ b/src/AstMock/MockBuffer.cpp
@@ -21,6 +21,7 @@
 #include "MockBuffer.hpp"
 #include "AstMath/LagrangeInterpolator.hpp"
 #include <stdlib.h> // for malloc and free
+#include <malloc.h> // for alloca
 
 AST_NAMESPACE_BEGIN
 

--- a/src/AstMock/MockUninitializedPointer.hpp
+++ b/src/AstMock/MockUninitializedPointer.hpp
@@ -36,6 +36,9 @@ public:
     MockUninitializedPointer();
     ~MockUninitializedPointer();
 
+    MockUninitializedPointer(const MockUninitializedPointer&) = delete;
+    MockUninitializedPointer& operator=(const MockUninitializedPointer&) = delete;
+
     void doSomething();
 private:
     Object* object_{};

--- a/src/AstOpt/NLPProblem.cpp
+++ b/src/AstOpt/NLPProblem.cpp
@@ -97,7 +97,7 @@ void aPrintSparityPatternCOO(int nnz, int* iFun, int* jVar, int idx_style)
 }
 
 NLPProblem::NLPProblem(INLPProblem* problem)
-	:m_problem{problem}
+	:m_problem{problem}, m_probInfo()
 {
 	assert(problem != nullptr);
 	// 1. 获取非线性问题的维度

--- a/src/AstPlot/Agg/AggBackend.cpp
+++ b/src/AstPlot/Agg/AggBackend.cpp
@@ -22,8 +22,10 @@
 #if defined(AST_WITH_AGG) && defined(AST_WITH_MATPLOT)
 
 #include <cstdio>
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/core/figure_type.h>
 #include <matplot/core/axes_type.h>
+A_SUPPRESS_WARNINGS_END
 
 #include "AggRenderer.hpp"
 #include "AggVisitor.hpp"
@@ -38,7 +40,7 @@ struct AggBackend::Impl {
 
     std::string window_title_ = "Figure";
 
-    std::unique_ptr<AggRenderer> renderer_;
+    std::unique_ptr<AggRenderer> renderer_{};
     matplot::figure_type* figure_ = nullptr;
 };
 

--- a/src/AstPlot/Agg/AggBackend.hpp
+++ b/src/AstPlot/Agg/AggBackend.hpp
@@ -24,7 +24,9 @@
 #include "AstGlobal.h"
 
 #if defined(AST_WITH_AGG) && defined(AST_WITH_MATPLOT)
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/backend/backend_interface.h>
+A_SUPPRESS_WARNINGS_END
 
 #include <memory>
 #include <string>

--- a/src/AstPlot/Agg/AggRenderer.cpp
+++ b/src/AstPlot/Agg/AggRenderer.cpp
@@ -6,7 +6,9 @@
 #include <cstring>
 #include <stdexcept>
 
+A_SUPPRESS_WARNINGS_BEGIN
 #include "agg/agg_conv_dash.h"
+A_SUPPRESS_WARNINGS_END
 
 #include "path_converters.h"
 

--- a/src/AstPlot/Agg/AggRenderer.hpp
+++ b/src/AstPlot/Agg/AggRenderer.hpp
@@ -4,6 +4,7 @@
 
 #if defined(AST_WITH_AGG)
 
+A_SUPPRESS_WARNINGS_BEGIN
 #include "agg/agg_basics.h"
 #include "agg/agg_rendering_buffer.h"
 #include "agg/agg_rasterizer_scanline_aa.h"
@@ -18,6 +19,7 @@
 #include "agg/agg_trans_affine.h"
 #include "agg/agg_color_rgba.h"
 #include "agg/agg_gsv_text.h"
+A_SUPPRESS_WARNINGS_END
 
 #include "LineStyle.hpp"
 
@@ -90,13 +92,13 @@ private:
     unsigned int width_, height_;
     double dpi_;
 
-    agg::int8u* pixBuffer_;
-    agg::rendering_buffer rbuf_;
-    pixfmt_type pixFmt_;
-    renderer_base_type renBase_;
-    renderer_aa_type renAA_;
-    rasterizer_type ras_;
-    scanline_type sl_;
+    agg::int8u* pixBuffer_{};
+    agg::rendering_buffer rbuf_{};
+    pixfmt_type pixFmt_{};
+    renderer_base_type renBase_{};
+    renderer_aa_type renAA_{};
+    rasterizer_type ras_{};
+    scanline_type sl_{};
 };
 
 

--- a/src/AstPlot/Agg/AggVisitor.cpp
+++ b/src/AstPlot/Agg/AggVisitor.cpp
@@ -2,11 +2,13 @@
 
 #if defined(AST_WITH_AGG) && defined(AST_WITH_MATPLOT)
 
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/core/axes_type.h>
 #include <matplot/core/axis_type.h>
 #include <matplot/core/figure_type.h>
 #include <matplot/axes_objects/line.h>
 #include <matplot/util/colors.h>
+A_SUPPRESS_WARNINGS_END
 
 #include "AggRenderer.hpp"
 #include "LineStyle.hpp"

--- a/src/AstPlot/Agg/AggVisitor.hpp
+++ b/src/AstPlot/Agg/AggVisitor.hpp
@@ -2,7 +2,9 @@
 
 #if defined(AST_WITH_MATPLOT) && defined(AST_WITH_AGG)
 
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/util/visitor.h>
+A_SUPPRESS_WARNINGS_END
 
 #include "AggRenderer.hpp"
 
@@ -13,6 +15,9 @@ AST_NAMESPACE_BEGIN
 class AggVisitor : public matplot::visitor {
 public:
     AggVisitor(AggRenderer& renderer, double fig_w, double fig_h);
+
+    AggVisitor(const AggVisitor&) = delete;
+    AggVisitor& operator=(const AggVisitor&) = delete;
 
     void setAxes(const matplot::axes_type& axes);
 
@@ -46,11 +51,11 @@ private:
     const agg::trans_affine& getTransform() const{return trans_;}
 
     AggRenderer& renderer_;
-    double fig_w_, fig_h_;
+    double fig_w_{}, fig_h_{};
 
     const matplot::axes_type* axes_{nullptr};
     double xmin_{0.0}, xmax_{1.0}, ymin_{0.0}, ymax_{1.0};
-    agg::trans_affine trans_;
+    agg::trans_affine trans_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstPlot/Agg/LineStyle.hpp
+++ b/src/AstPlot/Agg/LineStyle.hpp
@@ -4,8 +4,10 @@
 
 #if defined(AST_WITH_AGG) 
 
+A_SUPPRESS_WARNINGS_BEGIN
 #include "agg/agg_color_rgba.h"
 #include "agg/agg_math_stroke.h"
+A_SUPPRESS_WARNINGS_END
 #include "path_converters.h"  // e_snap_mode
 
 
@@ -22,7 +24,7 @@ struct LineStyle {
     e_snap_mode snap = SNAP_AUTO;
 
     double  dash_offset = 0.0;
-    std::vector<double> dash_pattern;   // 空 = 实线, 单位 pt (已按 lw 缩放)
+    std::vector<double> dash_pattern{};  // 空 = 实线, 单位 pt (已按 lw 缩放)
 
     bool simplify = true;
     double simplify_threshold = 0.111111; // M_SQRT2/9 ≈ matplot default

--- a/src/AstPlot/Agg/path_converters.h
+++ b/src/AstPlot/Agg/path_converters.h
@@ -8,8 +8,10 @@
 
 #if defined(AST_WITH_AGG)
 
+A_SUPPRESS_WARNINGS_BEGIN
 #include "agg/agg_clip_liang_barsky.h"
 #include "agg/agg_conv_segmentator.h"
+
 
 #include "mpl_utils.h"
 
@@ -477,4 +479,5 @@ private:
 };
 
 
+A_SUPPRESS_WARNINGS_END
 #endif // AST_WITH_AGG

--- a/src/AstPlot/Plot.hpp
+++ b/src/AstPlot/Plot.hpp
@@ -26,7 +26,9 @@
 #endif
 
 #ifdef _AST_USE_MATPLOT
+A_SUPPRESS_WARNINGS_BEGIN
 #include <matplot/matplot.h>
+A_SUPPRESS_WARNINGS_END
 #else
 #include "NoPlot.hpp"
 #endif

--- a/src/AstReport/Data/DataElements.hpp
+++ b/src/AstReport/Data/DataElements.hpp
@@ -136,8 +136,8 @@ public:
     }
     
 private:
-    std::vector<DataElement> elements_;                             ///< 数据元素列表
-    std::vector<std::pair<std::string, std::string>> aliasMap_;     ///< 别名映射
+    std::vector<DataElement> elements_{};                            ///< 数据元素列表
+    std::vector<std::pair<std::string, std::string>> aliasMap_{};    ///< 别名映射
 };
 
 const int i = sizeof(DataElements);

--- a/src/AstReport/Data/Impl/DataCalculation/DataGroupAttitude.hpp
+++ b/src/AstReport/Data/Impl/DataCalculation/DataGroupAttitude.hpp
@@ -40,7 +40,7 @@ class DataGroupAttitude : public DataGroupTimeVar
 public:
     struct Data
     {
-        KinematicRotation rotation;
+        KinematicRotation rotation{};
     };
     static DataElements Elements();
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupAnglePrv.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupAnglePrv.hpp
@@ -60,7 +60,7 @@ public:
 public:
     Angle* getAngle() const { return angle_.get(); }
 private:
-    WeakPtr<Angle> angle_;
+    WeakPtr<Angle> angle_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupBetaAngle.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupBetaAngle.hpp
@@ -72,10 +72,10 @@ public:
     void setSunPoint(Point* p)  { sunPoint_ = p; }
     void setMoonPoint(Point* p) { moonPoint_ = p; }
 private:
-    WeakPtr<Point> scPoint_;
-    WeakPtr<Frame> frame_;
-    WeakPtr<Point> sunPoint_;
-    WeakPtr<Point> moonPoint_;
+    WeakPtr<Point> scPoint_{};
+    WeakPtr<Frame> frame_{};
+    WeakPtr<Point> sunPoint_{};
+    WeakPtr<Point> moonPoint_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupCartPos.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupCartPos.hpp
@@ -64,8 +64,8 @@ public:
     void setPoint(Point* p) { point_ = p; }
     void setFrame(Frame* f) { frame_ = f; }
 private:
-    WeakPtr<Point> point_;
-    WeakPtr<Frame> frame_;
+    WeakPtr<Point> point_{};
+    WeakPtr<Frame> frame_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupCartVel.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupCartVel.hpp
@@ -82,8 +82,8 @@ public:
     void setPoint(Point* p) { point_ = p; }
     void setFrame(Frame* f) { frame_ = f; }
 private:
-    WeakPtr<Point> point_;
-    WeakPtr<Frame> frame_;
+    WeakPtr<Point> point_{};
+    WeakPtr<Frame> frame_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupEquinElem.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupEquinElem.hpp
@@ -42,7 +42,7 @@ public:
     {
         EquinElem equinElem_{};
         double    gm_{};
-        TimePoint time_;
+        TimePoint time_{}; 
 
         const TimePoint& getTime()           const { return time_; }
         double getSemiMajorAxis()            const { return equinElem_.a(); }
@@ -79,8 +79,8 @@ public:
     void setPoint(Point* p) { point_ = p; }
     void setFrame(Frame* f) { frame_ = f; }
 private:
-    WeakPtr<Point> point_;
-    WeakPtr<Frame> frame_;
+    WeakPtr<Point> point_{};
+    WeakPtr<Frame> frame_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupEuler.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupEuler.hpp
@@ -78,8 +78,8 @@ public:
     int  getRotationOrder() const { return rotationOrder_; }
     void setRotationOrder(int order) { rotationOrder_ = order; }
 private:
-    WeakPtr<Axes> axes_;
-    WeakPtr<Axes> referenceAxes_;
+    WeakPtr<Axes> axes_{};
+    WeakPtr<Axes> referenceAxes_{};
     int rotationOrder_{Euler::eXYX};
 };
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupLLAState.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupLLAState.hpp
@@ -44,13 +44,13 @@ class DataGroupLLAState : public DataGroupTimeVar
 public:
     struct Data
     {
-        TimePoint     time_;
-        GeodeticPoint detic_;
-        double        centricLat_;
-        double        centricLon_;
-        double        latRate_;
-        double        lonRate_;
-        double        altRate_;
+        TimePoint     time_{};
+        GeodeticPoint detic_{};
+        double        centricLat_{};
+        double        centricLon_{};
+        double        latRate_{};
+        double        lonRate_{};
+        double        altRate_{};
 
         const TimePoint& getTime()       const { return time_; }
         double           getLat()        const { return detic_.latitude(); }
@@ -87,8 +87,8 @@ public:
     void setPoint(Point* p) { scPoint_ = p; }
     void setBody(Body* b)     { body_ = b; }
 private:
-    WeakPtr<Point> scPoint_;
-    WeakPtr<Body>  body_;
+    WeakPtr<Point> scPoint_{};
+    WeakPtr<Body>  body_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupLLRState.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupLLRState.hpp
@@ -75,8 +75,8 @@ public:
     void setPoint(Point* p) { scPoint_ = p; }
     void setFrame(Frame* f)   { frame_ = f; }
 private:
-    WeakPtr<Point> scPoint_;
-    WeakPtr<Frame> frame_;
+    WeakPtr<Point> scPoint_{};
+    WeakPtr<Frame> frame_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupModOrbElem.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupModOrbElem.hpp
@@ -38,7 +38,7 @@ class DataGroupModOrbElem : public DataGroupTimeVar
 public:
     struct Data
     {
-        ModOrbElem modOrbElem_;
+        ModOrbElem modOrbElem_{};
         double bodyRadius_{};
         double gm_{};
         TimePoint time_{};
@@ -80,8 +80,8 @@ public:
     void setPoint(Point* p) { point_ = p; }
     void setFrame(Frame* f) { frame_ = f; }
 private:
-    WeakPtr<Point> point_;
-    WeakPtr<Frame> frame_;
+    WeakPtr<Point> point_{};
+    WeakPtr<Frame> frame_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupPointPrv.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupPointPrv.hpp
@@ -96,8 +96,8 @@ public:
     Point* getPoint() const { return point_.get(); }
     Frame* getFrame() const { return frame_.get(); }
 private:
-    WeakPtr<Point> point_;
-    WeakPtr<Frame> frame_;
+    WeakPtr<Point> point_{};
+    WeakPtr<Frame> frame_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupQuats.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupQuats.hpp
@@ -87,8 +87,8 @@ public:
     void setAxes(Axes* a)          { axes_ = a; }
     void setReferenceAxes(Axes* a) { referenceAxes_ = a; }
 private:
-    WeakPtr<Axes> axes_;                ///< 姿态轴
-    WeakPtr<Axes> referenceAxes_;       ///< 参考轴
+    WeakPtr<Axes> axes_{};                ///< 姿态轴
+    WeakPtr<Axes> referenceAxes_{};       ///< 参考轴
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupSpherical.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupSpherical.hpp
@@ -75,8 +75,8 @@ public:
     void setPoint(Point* p) { scPoint_ = p; }
     void setFrame(Frame* f)   { frame_ = f; }
 private:
-    WeakPtr<Point> scPoint_;
-    WeakPtr<Frame> frame_;
+    WeakPtr<Point> scPoint_{};
+    WeakPtr<Frame> frame_{};
 };
 
 

--- a/src/AstReport/Data/Impl/DataProvider/DataGroupVectorPrv.hpp
+++ b/src/AstReport/Data/Impl/DataProvider/DataGroupVectorPrv.hpp
@@ -90,7 +90,7 @@ public:
     Vector* getVector() const { return vector_.get(); }
     Axes*   getAxes()   const { return axes_.get(); }
 private:
-    WeakPtr<Vector> vector_;
+    WeakPtr<Vector> vector_{};
     WeakPtr<Axes>   axes_;
 };
 

--- a/src/AstReport/DataFrame/DataFrame.hpp
+++ b/src/AstReport/DataFrame/DataFrame.hpp
@@ -103,8 +103,8 @@ public:
 private:
     void rebuildIndex();
 
-    std::string                    name_;
-    std::vector<DataSeries>        columns_;
+    std::string                    name_{};
+    std::vector<DataSeries>        columns_{};
     std::map<std::string, size_t>  index_;  ///< 列名 → columns_ 下标
 };
 

--- a/src/AstReport/DataFrame/DataFrame.hpp
+++ b/src/AstReport/DataFrame/DataFrame.hpp
@@ -105,7 +105,7 @@ private:
 
     std::string                    name_{};
     std::vector<DataSeries>        columns_{};
-    std::map<std::string, size_t>  index_;  ///< 列名 → columns_ 下标
+    std::map<std::string, size_t>  index_{}; ///< 列名 → columns_ 下标
 };
 
 /*! @} */

--- a/src/AstReport/DataFrame/DataSeries.hpp
+++ b/src/AstReport/DataFrame/DataSeries.hpp
@@ -111,7 +111,7 @@ protected:
     friend class DataFrame;
 
     std::string name_;          ///< 数据名称
-    VariantVector data_;        ///< 数据向量
+    VariantVector data_{};       ///< 数据向量
 };
 
 

--- a/src/AstReport/ReportElement.hpp
+++ b/src/AstReport/ReportElement.hpp
@@ -40,47 +40,47 @@ AST_NAMESPACE_BEGIN
 ///          所有字段均为可选，空字符串表示使用场景默认单位。
 struct AST_REPORT_API ReportUnits
 {
-    std::string distanceUnit_;
-    std::string timeUnit_;
-    std::string dateFormat_;
-    std::string angleUnit_;
-    std::string massUnit_;
-    std::string powerUnit_;
-    std::string frequencyUnit_;
-    std::string smallDistanceUnit_;
-    std::string latitudeUnit_;
-    std::string longitudeUnit_;
-    std::string durationUnit_;
-    std::string temperature_;
-    std::string smallTimeUnit_;
-    std::string ratioUnit_;
-    std::string rcsUnit_;
-    std::string dopplerVelocityUnit_;
-    std::string sarTimeResProdUnit_;
-    std::string forceUnit_;
-    std::string pressureUnit_;
-    std::string specificImpulseUnit_;
-    std::string prfUnit_;
-    std::string bandwidthUnit_;
-    std::string smallVelocityUnit_;
-    std::string dataRateUnit_;
-    std::string percent_;
-    std::string unitTemperature_;
-    std::string missionModelerDistanceUnit_;
-    std::string missionModelerTimeUnit_;
-    std::string missionModelerAltitudeUnit_;
-    std::string missionModelerFuelQuantityUnit_;
-    std::string missionModelerRunwayLengthUnit_;
-    std::string missionModelerBearingAngleUnit_;
-    std::string missionModelerAngleOfAttackUnit_;
-    std::string missionModelerAttitudeAngleUnit_;
-    std::string missionModelerGUnit_;
-    std::string solidAngle_;
-    std::string radiationDoseUnit_;
-    std::string radiationShieldThicknessUnit_;
-    std::string magneticFieldUnit_;
-    std::string powerFluxDensityUnit_;
-    std::string spectralDensityUnit_;
+    std::string distanceUnit_{};
+    std::string timeUnit_{};
+    std::string dateFormat_{};
+    std::string angleUnit_{};
+    std::string massUnit_{};
+    std::string powerUnit_{};
+    std::string frequencyUnit_{};
+    std::string smallDistanceUnit_{};
+    std::string latitudeUnit_{};
+    std::string longitudeUnit_{};
+    std::string durationUnit_{};
+    std::string temperature_{};
+    std::string smallTimeUnit_{};
+    std::string ratioUnit_{};
+    std::string rcsUnit_{};
+    std::string dopplerVelocityUnit_{};
+    std::string sarTimeResProdUnit_{};
+    std::string forceUnit_{};
+    std::string pressureUnit_{};
+    std::string specificImpulseUnit_{};
+    std::string prfUnit_{};
+    std::string bandwidthUnit_{};
+    std::string smallVelocityUnit_{};
+    std::string dataRateUnit_{};
+    std::string percent_{};
+    std::string unitTemperature_{};
+    std::string missionModelerDistanceUnit_{};
+    std::string missionModelerTimeUnit_{};
+    std::string missionModelerAltitudeUnit_{};
+    std::string missionModelerFuelQuantityUnit_{};
+    std::string missionModelerRunwayLengthUnit_{};
+    std::string missionModelerBearingAngleUnit_{};
+    std::string missionModelerAngleOfAttackUnit_{};
+    std::string missionModelerAttitudeAngleUnit_{};
+    std::string missionModelerGUnit_{};
+    std::string solidAngle_{};
+    std::string radiationDoseUnit_{};
+    std::string radiationShieldThicknessUnit_{};
+    std::string magneticFieldUnit_{};
+    std::string powerFluxDensityUnit_{};
+    std::string spectralDensityUnit_{};
 };
 
 /// @brief 报表数据元素
@@ -90,21 +90,21 @@ class AST_REPORT_API ReportElement
 {
 public:
     // ---- 标识 ----
-    std::string name_;           ///< 元素名称（限定名，如 "Classical Elements-J2000-Semi-major Axis"）
-    std::string title_;          ///< 显示标题
+    std::string name_{};           ///< 元素名称（限定名，如 "Classical Elements-J2000-Semi-major Axis"）
+    std::string title_{};          ///< 显示标题
     bool        nameInTitle_ = true;
 
     // ---- 自变量 ----
     bool        isIndepVar_ = false;   ///< 是否为自变量（通常是时间）
-    std::string indepVarName_;          ///< 自变量名称（如 "Time"）
+    std::string indepVarName_{};          ///< 自变量名称（如 "Time"）
 
     // ---- 数据来源 ----
-    std::string service_;   ///< 数据提供者服务名（如 "ModOrbElem", "LLAState", "InviewData"）
-    std::string type_;      ///< 数据类型/参考系（如 "J2000", "Fixed", "Sunlight"）
-    std::string element_;   ///< 要检索的数据元素名（如 "Semi-major Axis", "Time"）
+    std::string service_{};   ///< 数据提供者服务名（如 "ModOrbElem", "LLAState", "InviewData"）
+    std::string type_{};      ///< 数据类型/参考系（如 "J2000", "Fixed", "Sunlight"）
+    std::string element_{};   ///< 要检索的数据元素名（如 "Semi-major Axis", "Time"）
 
     // ---- 格式化 ----
-    std::string format_;    ///< 输出格式字符串（如 "%.3f", "%.6f", "%d"）
+    std::string format_{};    ///< 输出格式字符串（如 "%.3f", "%.6f", "%d"）
 
     // ---- 聚合 ----
     int  sumAllowedMask_ = 0;
@@ -128,7 +128,7 @@ public:
     // ---- 其他 ----
     int  propMask_     = 0;
     bool useScenUnits_ = true;   ///< 是否使用场景单位（No 时启用自定义 units_）
-    ReportUnits units_;            ///< 自定义单位（仅当 useScenUnits_ == false 时有效）
+    ReportUnits units_{};            ///< 自定义单位（仅当 useScenUnits_ == false 时有效）
 };
 
 /*! @} */

--- a/src/AstReport/ReportLine.hpp
+++ b/src/AstReport/ReportLine.hpp
@@ -40,10 +40,10 @@ AST_NAMESPACE_BEGIN
 class AST_REPORT_API ReportLine
 {
 public:
-    std::string name_;    ///< 行名称（如 "Line 1"）
-    std::string title_;   ///< 图形样式的 Y 轴/序列标题（表格样式不适用）
+    std::string name_{};   ///< 行名称（如 "Line 1"）
+    std::string title_{};  ///< 图形样式的 Y 轴/序列标题（表格样式不适用）
 
-    std::vector<ReportElement> elements_;
+    std::vector<ReportElement> elements_{};
 };
 
 /*! @} */

--- a/src/AstReport/ReportSection.hpp
+++ b/src/AstReport/ReportSection.hpp
@@ -40,15 +40,15 @@ AST_NAMESPACE_BEGIN
 class AST_REPORT_API ReportSection
 {
 public:
-    std::string name_;             ///< 段名称（如 "Section 1"）
-    std::string className_;        ///< 对象类型名（如 "Satellite", "Facility"）
+    std::string name_{};             ///< 段名称（如 "Section 1"）
+    std::string className_{};        ///< 对象类型名（如 "Satellite", "Facility"）
     bool        nameInTitle_ = true;
     EExpandMethod expandMethod_ = EExpandMethod::eNone; ///< 展开方式
     int         propMask_     = 2;
     bool        showIntervals_ = false;
     int         numIntervals_  = 0;
 
-    std::vector<ReportLine> lines_;
+    std::vector<ReportLine> lines_{};
 };
 
 /*! @} */

--- a/src/AstReport/ReportWriter.cpp
+++ b/src/AstReport/ReportWriter.cpp
@@ -186,18 +186,18 @@ static const std::unordered_map<StringView, ADataGroupFactory> s_serviceFactorie
 /// @brief 列数据 — extract 后的带类型列及其缓存 Span
 struct ColData
 {
-    const ReportElement* element;
-    std::string title;
-    int  width;
+    const ReportElement* element{};
+    std::string title{};
+    int  width{};
 
-    EDataType dataType;
-    VariantVector data;  // 持有列数据，Span 指向此处
+    EDataType dataType{};
+    VariantVector data{};  // 持有列数据，Span 指向此处
 
     // 缓存 Span（每种类型一个有效，指向 data 内部缓冲区）
-    Span<double>      dSpan;
-    Span<int>         iSpan;
-    Span<TimePoint>   tSpan;
-    Span<std::string> sSpan;
+    Span<double>      dSpan{};
+    Span<int>         iSpan{};
+    Span<TimePoint>   tSpan{};
+    Span<std::string> sSpan{};
 };
 
 /// @brief 从 ColData::data 推断类型并缓存 Span

--- a/src/AstSPICE/RunTime/SpiceFrameRegistry.hpp
+++ b/src/AstSPICE/RunTime/SpiceFrameRegistry.hpp
@@ -46,7 +46,7 @@ public:
 
 private:
     using FrameMap = std::unordered_map<std::string, HFrame>;
-    FrameMap frameMap_;
+    FrameMap frameMap_{};
 };
 
 

--- a/src/AstScript/Basic/ExprExpandVisitor.hpp
+++ b/src/AstScript/Basic/ExprExpandVisitor.hpp
@@ -74,7 +74,7 @@ public:
     void setResult(Expr* result) {result_ = result;}
 private:
     void visitValue(Value& value);
-    SharedPtr<Expr> result_;
+    SharedPtr<Expr> result_{};
 };
 
 #endif

--- a/src/AstScript/Expression/ExprContainer.hpp
+++ b/src/AstScript/Expression/ExprContainer.hpp
@@ -57,7 +57,7 @@ public:
     /// @return 表达式容器引用
     const VectorType& children() const { return elems_; }
 protected:
-    VectorType elems_;      ///< 表达式容器
+    VectorType elems_{};     ///< 表达式容器
 };
 
 AST_NAMESPACE_END

--- a/src/AstScript/Expression/ExprIf.cpp
+++ b/src/AstScript/Expression/ExprIf.cpp
@@ -25,7 +25,7 @@
 
 AST_NAMESPACE_BEGIN
 
-ExprIf::ExprIf(){}
+ExprIf::ExprIf() : conditionBranches_(), elseBlock_(){}
 
 ExprIf::ExprIf(Expr * condition, Expr * block)
     :ExprIf()

--- a/src/AstScript/Foreign/PythonAPI.cpp
+++ b/src/AstScript/Foreign/PythonAPI.cpp
@@ -81,6 +81,7 @@ PythonAPI* PythonAPI::Instance()
 
 
 PythonAPI::PythonAPI(bool shouldLoadDynamicLib)
+    : mutex_()
 {
     if(shouldLoadDynamicLib)
     {

--- a/src/AstScript/Foreign/ScriptExecutor/ActiveScriptExecutor.cpp
+++ b/src/AstScript/Foreign/ScriptExecutor/ActiveScriptExecutor.cpp
@@ -29,8 +29,14 @@
 AST_NAMESPACE_BEGIN
 
 class ActiveScriptExecutor::Impl{};
-ActiveScriptExecutor::ActiveScriptExecutor(){aError("ActiveScriptExecutor not supported on this platform");}
-ActiveScriptExecutor::ActiveScriptExecutor(const wchar_t* progId){}
+ActiveScriptExecutor::ActiveScriptExecutor()
+    : impl_(nullptr)
+{
+    aError("ActiveScriptExecutor not supported on this platform");
+}
+ActiveScriptExecutor::ActiveScriptExecutor(const wchar_t* progId)
+    : impl_(nullptr)
+{}
 ActiveScriptExecutor::~ActiveScriptExecutor() = default;
 errc_t ActiveScriptExecutor::initialize() {return -1;};
 void ActiveScriptExecutor::finalize() {}

--- a/src/AstScript/Foreign/ScriptExecutor/ActiveScriptExecutor.cpp
+++ b/src/AstScript/Foreign/ScriptExecutor/ActiveScriptExecutor.cpp
@@ -204,9 +204,17 @@ void VariantToValue(const VARIANT& v, SharedPtr<Value>& value)
 
 // 站点实现（简化版，仅实现IActiveScriptSite的部分方法）
 
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif
 class SimpleActiveScriptSite final: public IActiveScriptSite
 {
 public:
+    SimpleActiveScriptSite(const SimpleActiveScriptSite&) = delete;
+    SimpleActiveScriptSite& operator=(const SimpleActiveScriptSite&) = delete;
+
     SimpleActiveScriptSite()
     {
         globalFunctions_ = new ActiveScriptGlobalFunctions();
@@ -298,9 +306,12 @@ public:
     bool hasError() const {return !lastError_.empty();}
 private:
     LONG ref_ = 1;
-    std::string lastError_;
+    std::string lastError_{};
     ActiveScriptGlobalFunctions* globalFunctions_ = nullptr;
 };
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 
 
@@ -310,7 +321,7 @@ class CoInitializeGuard
 public:
     CoInitializeGuard(COINIT initFlags) {hr_ = CoInitializeEx(nullptr, initFlags);}
     ~CoInitializeGuard() {if (SUCCEEDED(hr_)) CoUninitialize();}
-    HRESULT hr_;
+    HRESULT hr_{};
 };
 
 /// 确保当前线程 COM 已初始化
@@ -330,9 +341,12 @@ public:
     IDispatch*                  pGlobal = nullptr;          ///< 脚本全局对象的 IDispatch
     SimpleActiveScriptSite*     pSite = nullptr;            ///< 脚本站点
     std::wstring                progId = L"JScript";        ///< 默认脚本引擎
-    
+
 public:
     Impl() = default;
+
+    Impl(const Impl&) = delete;
+    Impl& operator=(const Impl&) = delete;
     
     ~Impl()
     {

--- a/src/AstScript/Foreign/ScriptExecutor/ActiveScriptGlobalFunctions.inl
+++ b/src/AstScript/Foreign/ScriptExecutor/ActiveScriptGlobalFunctions.inl
@@ -39,6 +39,11 @@ AST_NAMESPACE_BEGIN
 
 
 // 1. 实现 IDispatch 的全局函数提供者
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif
 class ActiveScriptGlobalFunctions final: public IDispatch {
 private:
     LONG m_ref;
@@ -112,6 +117,9 @@ public:
         return DISP_E_MEMBERNOTFOUND;
     }
 };
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 
 /*! @} */

--- a/src/AstScript/Foreign/ScriptExecutor/PythonExecutor.hpp
+++ b/src/AstScript/Foreign/ScriptExecutor/PythonExecutor.hpp
@@ -38,6 +38,10 @@ class AST_SCRIPT_API PythonExecutor : public ScriptExecutor
 {
 public:
     PythonExecutor();
+
+    PythonExecutor(const PythonExecutor&) = delete;
+    PythonExecutor& operator=(const PythonExecutor&) = delete;
+
     ~PythonExecutor() override;
 
     errc_t initialize() override;
@@ -67,7 +71,7 @@ protected:
 protected:
     PythonAPI* api_;
     PyObject* globals_{nullptr};  // 私有无名 dict，每个 executor 独立命名空间
-    mutable std::string lastError_;
+    mutable std::string lastError_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstScript/Foreign/ScriptExecutor/ScriptExecutor.hpp
+++ b/src/AstScript/Foreign/ScriptExecutor/ScriptExecutor.hpp
@@ -66,8 +66,8 @@ public:
     const std::string& error() const { return error_; }
     Value* value() const { return value_.get(); }
 
-    std::string error_;         ///< 错误信息
-    SharedPtr<Value> value_;    ///< 返回值
+    std::string error_{};         ///< 错误信息
+    SharedPtr<Value> value_{};    ///< 返回值
 };
 
 /// @brief 脚本执行器，用于执行外部脚本

--- a/src/AstScript/Interpreter/Interpreter.hpp
+++ b/src/AstScript/Interpreter/Interpreter.hpp
@@ -83,7 +83,7 @@ public:
 
 protected:
     std::unique_ptr<ISymbolScope> symbolScope_;       ///< 当前作用域
-    std::string errString_;                           ///< 错误字符串
+    std::string errString_{};                          ///< 错误字符串
 };
 
 

--- a/src/AstScript/Interpreter/SymbolScope.hpp
+++ b/src/AstScript/Interpreter/SymbolScope.hpp
@@ -68,6 +68,9 @@ public:
     /// @brief 默认构造函数
     SymbolScope() = default;
 
+    SymbolScope(const SymbolScope&) = delete;
+    SymbolScope& operator=(const SymbolScope&) = delete;
+
     /// @brief 构造函数，指定父符号作用域
     /// @param parent 父符号作用域指针
     explicit SymbolScope(SymbolScope* parent)
@@ -113,7 +116,7 @@ public:
     void setParent(SymbolScope* parent);
 
 protected:
-    SymbolMap    symbols_;              ///< 符号作用域中的符号
+    SymbolMap    symbols_{};             ///< 符号作用域中的符号
     SymbolScope* parent_ = nullptr;     ///< 父符号作用域指针
 };
 

--- a/src/AstScript/Operator/OpBin.hpp
+++ b/src/AstScript/Operator/OpBin.hpp
@@ -37,7 +37,7 @@ public:
 
 public:
     OpBin(EOpBinType op, Expr* left, Expr* right)
-        : op_(op), left_(left), right_(right)
+        : op_(op), left_(left), right_(right), cache_mutex_()
     {};
     virtual ~OpBin() = default;
     Value* eval() const override;

--- a/src/AstScript/Operator/OpUnary.hpp
+++ b/src/AstScript/Operator/OpUnary.hpp
@@ -36,7 +36,7 @@ public:
     AST_EXPR(OpUnary)
 
     OpUnary(EOpUnaryType op, Expr* expr)
-        : op_(op), expr_(expr)
+        : op_(op), expr_(expr), cache_mutex_()
     {};
     virtual ~OpUnary() = default;
     Value* eval() const override;

--- a/src/AstScript/Operator/Predefined/OpBinRegistry.hpp
+++ b/src/AstScript/Operator/Predefined/OpBinRegistry.hpp
@@ -64,7 +64,7 @@ public:
         map_[OpBinKey{static_cast<int>(op), leftType, rightType}] = func;
     }
 protected:
-    OpBinMap map_;
+    OpBinMap map_{};
 };
 
 #endif

--- a/src/AstScript/Operator/Predefined/OpUnaryRegister.hpp
+++ b/src/AstScript/Operator/Predefined/OpUnaryRegister.hpp
@@ -63,7 +63,7 @@ public:
         map_[OpUnaryKey{static_cast<int>(op), type}] = func;
     }
 protected:
-    OpUnaryMap map_;
+    OpUnaryMap map_{};
 };
 #endif
 

--- a/src/AstScript/Parser/Lexer.hpp
+++ b/src/AstScript/Parser/Lexer.hpp
@@ -114,11 +114,14 @@ public:
     };
 
 public:
-    explicit Lexer(Scanner* scanner) 
+    explicit Lexer(Scanner* scanner)
         : scanner_(scanner)
         // , line_(1)
-        , current_lexeme_() 
+        , current_lexeme_()
     {}
+
+    Lexer(const Lexer&) = delete;
+    Lexer& operator=(const Lexer&) = delete;
     
     /// @brief 获取下一个令牌
     ETokenType getNextToken();

--- a/src/AstScript/Parser/Scanner.hpp
+++ b/src/AstScript/Parser/Scanner.hpp
@@ -88,15 +88,18 @@ private:
 class AST_SCRIPT_API FileScanner : public Scanner
 {
 public:
-    explicit FileScanner(FILE* file) 
-        : file_(file), current_char_(0), next_char_(0), at_end_(false) 
+    explicit FileScanner(FILE* file)
+        : file_(file), current_char_(0), next_char_(0), at_end_(false)
     {
         // 预读取两个字符
         current_char_ = std::fgetc(file_);
         next_char_ = std::fgetc(file_);
         at_end_ = (current_char_ == EOF);
     }
-    
+
+    FileScanner(const FileScanner&) = delete;
+    FileScanner& operator=(const FileScanner&) = delete;
+
     ~FileScanner() override;
     
     char consume() override;

--- a/src/AstScript/Value/ValDict.hpp
+++ b/src/AstScript/Value/ValDict.hpp
@@ -53,7 +53,7 @@ public:
 protected:
     std::string toJsonString(int indent, int currentIndent) const;
 protected:
-    MapType map_;
+    MapType map_{};
 };
 
 /*! @} */

--- a/src/AstScript/Value/ValNamedVector.hpp
+++ b/src/AstScript/Value/ValNamedVector.hpp
@@ -54,7 +54,7 @@ public:
 
     std::string getExpression(Object* object) const override;
 private:
-    VectorType vector_;
+    VectorType vector_{};
 };
 
 

--- a/src/AstScript/Variable/Variable.cpp
+++ b/src/AstScript/Variable/Variable.cpp
@@ -35,14 +35,16 @@ Variable* Variable::New()
 
 
 Variable::Variable(StringView name, Expr *expr, bool bind)
-    : expr_(expr)
+    : desc_()
+    , expr_(expr)
     , bind_(bind)
 {
     this->setName(name);
 };
 
 Variable::Variable(Expr *expr, bool bind)
-    : expr_(expr)
+    : desc_()
+    , expr_(expr)
     , bind_(bind)
 {};
 

--- a/src/AstSim/Foundation/CentroidPosition.hpp
+++ b/src/AstSim/Foundation/CentroidPosition.hpp
@@ -51,7 +51,7 @@ public:
     double longitude() const {return position_.longitude();}
     double altitude() const {return position_.altitude();}
 private:
-    SharedPtr<Body>     body_;                ///< 天体名称
+    SharedPtr<Body>     body_{};               ///< 天体名称
     GeodeticPoint       position_{};          ///< 质心位置点
 };
 

--- a/src/AstSim/Motion/Abstract/MotionOrbitDynamics.hpp
+++ b/src/AstSim/Motion/Abstract/MotionOrbitDynamics.hpp
@@ -74,8 +74,8 @@ PROPERTIES:
     Frame* getPropagationFrame() const { return propagationFrame_.get(); }
     void setPropagationFrame(Frame* frame) { propagationFrame_ = frame; }
 protected:
-    SharedPtr<State>            initialState_;          ///< 初始状态
-    SharedPtr<Frame>            propagationFrame_;      ///< 预报坐标系
+    SharedPtr<State>            initialState_{};         ///< 初始状态
+    SharedPtr<Frame>            propagationFrame_{};     ///< 预报坐标系
 };
 
 /*! @} */

--- a/src/AstSim/Motion/Abstract/MotionWithIntervalStep.hpp
+++ b/src/AstSim/Motion/Abstract/MotionWithIntervalStep.hpp
@@ -59,7 +59,7 @@ public:
     /// @param stepSize 预报步长
     void setStepSize(double stepSize) { stepSize_ = stepSize; }
 protected:
-    SharedPtr<EventInterval>    interval_;              ///< 时间段
+    SharedPtr<EventInterval>    interval_{};             ///< 时间段
     double                      stepSize_{60.0};        ///< 生成星历步长
 };
 

--- a/src/AstSim/Motion/MotionBallistic.hpp
+++ b/src/AstSim/Motion/MotionBallistic.hpp
@@ -175,21 +175,21 @@ public:
     double getLaunchApogeeAlt() const { return launchApogeeAlt_; }
     
 private:
-    TimePoint launchTime_;      ///< 发射时间
-    TimePoint impactTime_;      ///< 撞击时间
-    double launchLatitude_;     ///< 发射纬度（度）
-    double launchLongitude_;    ///< 发射经度（度）
-    double launchAltitude_;     ///< 发射高度（米）
-    double impactLatitude_;     ///< 撞击纬度（度）
-    double impactLongitude_;    ///< 撞击经度（度）
-    double impactAltitude_;     ///< 撞击高度（米）
-    double launchVelocity_;     ///< 发射速度（米/秒）
-    double launchAzimuth_;      ///< 发射方位角（度）
-    double launchElevation_;    ///< 发射仰角（度）
-    double launchDuration_;     ///< 发射持续时间（秒）
-    int launchType_;            ///< 发射类型
-    int launchControl_;         ///< 发射控制
-    double launchApogeeAlt_;    ///< 近地点高度（米）
+    TimePoint launchTime_{};      ///< 发射时间
+    TimePoint impactTime_{};      ///< 撞击时间
+    double launchLatitude_{};     ///< 发射纬度（度）
+    double launchLongitude_{};    ///< 发射经度（度）
+    double launchAltitude_{};     ///< 发射高度（米）
+    double impactLatitude_{};     ///< 撞击纬度（度）
+    double impactLongitude_{};    ///< 撞击经度（度）
+    double impactAltitude_{};     ///< 撞击高度（米）
+    double launchVelocity_{};     ///< 发射速度（米/秒）
+    double launchAzimuth_{};      ///< 发射方位角（度）
+    double launchElevation_{};    ///< 发射仰角（度）
+    double launchDuration_{};     ///< 发射持续时间（秒）
+    int launchType_{};            ///< 发射类型
+    int launchControl_{};         ///< 发射控制
+    double launchApogeeAlt_{};    ///< 近地点高度（米）
 
 };
 

--- a/src/AstSim/Motion/MotionGreatArc.hpp
+++ b/src/AstSim/Motion/MotionGreatArc.hpp
@@ -69,8 +69,8 @@ public:
     const WayPointVector& getWayPoints() const{return wayPoints_;}
     void setWayPoints(const WayPointVector& wayPoints){wayPoints_ = wayPoints;}
 private:
-    SharedPtr<EventTime> startTime_;        ///< 开始时间
-    WayPointVector wayPoints_;              ///< 路径点
+    SharedPtr<EventTime> startTime_{};       ///< 开始时间
+    WayPointVector wayPoints_{};             ///< 路径点
 };
 
 /*! @} */

--- a/src/AstSim/Motion/MotionHPOP.hpp
+++ b/src/AstSim/Motion/MotionHPOP.hpp
@@ -72,9 +72,9 @@ public:
     /// @return 积分器
     ODEIntegrator* getIntegrator() const;
 private:
-    HPOPForceModel forceModel_;             ///< 力模型
-    SpacecraftParam spacecraftParam_;       ///< 航天器参数
-    SharedPtr<ODEIntegrator> integrator_;   ///< 积分器
+    HPOPForceModel forceModel_{};            ///< 力模型
+    SpacecraftParam spacecraftParam_{};      ///< 航天器参数
+    SharedPtr<ODEIntegrator> integrator_{};  ///< 积分器
 };
 
 /*! @} */

--- a/src/AstSim/Motion/MotionMissionCommand.hpp
+++ b/src/AstSim/Motion/MotionMissionCommand.hpp
@@ -58,7 +58,7 @@ public:
     errc_t makeEphemerisSimple(ScopedPtr<Ephemeris>& eph) const override;
     void accept(MotionProfileVisitor& visitor) override;
 private:
-    SharedPtr<MainSequence> mainSequence_;      ///< 任务序列协调器
+    SharedPtr<MainSequence> mainSequence_{};     ///< 任务序列协调器
 };
 
 /*! @} */

--- a/src/AstSim/Motion/MotionSGP4.hpp
+++ b/src/AstSim/Motion/MotionSGP4.hpp
@@ -37,9 +37,9 @@ class TLE
 public:
     bool empty() const{return line1_.empty();}
 public:
-    std::string name_;      ///< 卫星名称
-    std::string line1_;     ///< 第一行
-    std::string line2_;     ///< 第二行
+    std::string name_{};     ///< 卫星名称
+    std::string line1_{};    ///< 第一行
+    std::string line2_{};    ///< 第二行
 };
 
 enum class ETLESource
@@ -66,8 +66,8 @@ public:
         {ETLESource::eFile};                 
     ESwitchMethod switch_method_ ///< 切换方法
         {ESwitchMethod::eEpoch};  
-    TimePoint switchEpoch_;      ///< 切换历元
-    TLE tle_;                    ///< TLE 数据
+    TimePoint switchEpoch_{};     ///< 切换历元
+    TLE tle_{};                   ///< TLE 数据
     double epochTime_{0.0};           ///< 历元时间
     double meanMotionDotTime_{0.0};   ///< 平均运动导数
     double motionDotDot_{0.0};        ///< 平均运动二阶导数
@@ -98,10 +98,10 @@ public:
     errc_t makeEphemerisSimple(ScopedPtr<Ephemeris>& eph) const override;
     void accept(MotionProfileVisitor& visitor) override;
 public:
-    std::string SSCNumber_;                 ///< SSC 编号字符串
-    std::string intlDesignator_;            ///< 
-    std::string commonName_;                ///< 通用名称
-    std::vector<TwoLineElement> elements_;  ///< 两行元素列表
+    std::string SSCNumber_{};                ///< SSC 编号字符串
+    std::string intlDesignator_{};           ///<
+    std::string commonName_{};               ///< 通用名称
+    std::vector<TwoLineElement> elements_{}; ///< 两行元素列表
 };
 
 /*! @} */

--- a/src/AstSim/Motion/MotionSPICE.hpp
+++ b/src/AstSim/Motion/MotionSPICE.hpp
@@ -56,7 +56,7 @@ public:
 protected:
     int spiceIndex_{};                    ///< SPICE星历索引号
 private:
-    JplSpk spk_;                        ///< SPICE星历接口
+    JplSpk spk_{};                       ///< SPICE星历接口
 };
 
 /*! @} */

--- a/src/AstSim/Motion/MotionSimpleAscent.hpp
+++ b/src/AstSim/Motion/MotionSimpleAscent.hpp
@@ -149,14 +149,14 @@ public:
     double getGranularity() const { return granularity_; }
     
 private:
-    TimePoint launchTime_;          ///< 发射时间
-    bool useScenTime_;              ///< 是否使用场景时间
-    TimePoint burnoutTime_;         ///< 关机时间
-    WeakPtr<CelestialBody> body_;   ///< 天体
-    GeodeticPoint launchPosition_;  ///< 发射位置
-    GeodeticPoint burnoutPosition_; ///< 关机位置
-    double burnoutVelocity_;        ///< 关机速度（米/秒）
-    double granularity_;            ///< 时间粒度（秒）
+    TimePoint launchTime_{};          ///< 发射时间
+    bool useScenTime_{};              ///< 是否使用场景时间
+    TimePoint burnoutTime_{};         ///< 关机时间
+    WeakPtr<CelestialBody> body_{};   ///< 天体
+    GeodeticPoint launchPosition_{};  ///< 发射位置
+    GeodeticPoint burnoutPosition_{}; ///< 关机位置
+    double burnoutVelocity_{};        ///< 关机速度（米/秒）
+    double granularity_{};            ///< 时间粒度（秒）
 };
 
 /*! @} */

--- a/src/AstSim/Object/Facility.hpp
+++ b/src/AstSim/Object/Facility.hpp
@@ -71,8 +71,8 @@ PROPERTIES:
     Body* body() const {return position_.body();}
     void setBody(Body* body) {position_.setBody(body);}
 protected:
-    std::string name_;
-    CentroidPosition position_;
+    std::string name_{};
+    CentroidPosition position_{};
 };
 
 /*! @} */

--- a/src/AstSim/Object/Mover.hpp
+++ b/src/AstSim/Object/Mover.hpp
@@ -103,10 +103,10 @@ public:
     State* getInitialState() const;
 
 protected:
-    std::string                 name_;                  ///< 名称
-    WeakPtr<MotionProfile>      motionProfile_;         ///< 运动定义
-    WeakPtr<AttitudeProfile>    attitudeProfile_;       ///< 姿态定义
-    ScopedPtr<Ephemeris>        ephemeris_;             ///< 星历
+    std::string                 name_{};                 ///< 名称
+    WeakPtr<MotionProfile>      motionProfile_{};        ///< 运动定义
+    WeakPtr<AttitudeProfile>    attitudeProfile_{};      ///< 姿态定义
+    ScopedPtr<Ephemeris>        ephemeris_{};            ///< 星历
 };
 
 /*! @} */

--- a/src/AstSim/Object/Scenario.hpp
+++ b/src/AstSim/Object/Scenario.hpp
@@ -91,12 +91,12 @@ public:
 
     void setPrimaryBody(CelestialBody* body);
 protected:
-    std::string name_;                        ///< 场景名称
-    SharedPtr<EventTime> epoch_;              ///< 场景历元时间
-    SharedPtr<EventInterval> interval_;       ///< 场景时间间隔
-    std::string eopFileName_;                 ///< EOP文件名
+    std::string name_{};                       ///< 场景名称
+    SharedPtr<EventTime> epoch_{};             ///< 场景历元时间
+    SharedPtr<EventInterval> interval_{};      ///< 场景时间间隔
+    std::string eopFileName_{};                ///< EOP文件名
     bool inheritEOPSource_{};                 ///< 是否继承EOP来源设置
-    SharedPtr<CelestialBody> primaryBody_;    ///< 场景天体
+    SharedPtr<CelestialBody> primaryBody_{};   ///< 场景天体
 };
 
 /*! @} */

--- a/src/AstSim/Object/Sensor.hpp
+++ b/src/AstSim/Object/Sensor.hpp
@@ -58,9 +58,9 @@ public:
     FieldOfView* getFieldOfView() const { return fov_; }
 
 private:
-    std::string name_;               ///< 传感器名称
-    WeakPtr<Point> location_;        ///< 传感器位置点, 这里使用弱引用
-    SharedPtr<FieldOfView> fov_;     ///< 传感器视场定义
+    std::string name_{};              ///< 传感器名称
+    WeakPtr<Point> location_{};       ///< 传感器位置点, 这里使用弱引用
+    SharedPtr<FieldOfView> fov_{};    ///< 传感器视场定义
 };
 
 /*! @} */

--- a/src/AstUiAI/Chat/UiChatEventHandler.hpp
+++ b/src/AstUiAI/Chat/UiChatEventHandler.hpp
@@ -107,7 +107,7 @@ Q_SIGNALS:
 
 private:
     std::atomic<bool>       cancelled_{false};
-    MarkdownHTMLRenderer    mdRenderer_;        // 流式 Markdown→HTML 渲染器
+    MarkdownHTMLRenderer    mdRenderer_{};        // 流式 Markdown→HTML 渲染器
 };
 
 /*! @} */

--- a/src/AstUiAI/Chat/UiChatInput.hpp
+++ b/src/AstUiAI/Chat/UiChatInput.hpp
@@ -34,6 +34,9 @@ public:
     explicit UiChatInput(QWidget* parent = nullptr);
     ~UiChatInput() override;
 
+    UiChatInput(const UiChatInput&) = delete;
+    UiChatInput& operator=(const UiChatInput&) = delete;
+
     /// @brief 设置发送按钮是否可用
     void setSendEnabled(bool enabled);
 

--- a/src/AstUiAI/Chat/UiChatMainWidget.hpp
+++ b/src/AstUiAI/Chat/UiChatMainWidget.hpp
@@ -40,6 +40,8 @@ public:
     explicit UiChatMainWidget(ChatSession* session, QWidget* parent = nullptr);
 
     ~UiChatMainWidget() override;
+    UiChatMainWidget(const UiChatMainWidget&) = delete;
+    UiChatMainWidget& operator=(const UiChatMainWidget&) = delete;
 
     /// @brief 获取聊天面板
     UiChatPanel* chatPanel() const { return chatPanel_; }

--- a/src/AstUiAI/Chat/UiChatMessageItem.hpp
+++ b/src/AstUiAI/Chat/UiChatMessageItem.hpp
@@ -44,6 +44,8 @@ public:
                                QWidget* parent = nullptr);
 
     ~UiChatMessageItem() override;
+    UiChatMessageItem(const UiChatMessageItem&) = delete;
+    UiChatMessageItem& operator=(const UiChatMessageItem&) = delete;
 
     /// @brief 设置消息内容（替换全部）
     void setContent(const QString& content);

--- a/src/AstUiAI/Chat/UiChatMessageItem.hpp
+++ b/src/AstUiAI/Chat/UiChatMessageItem.hpp
@@ -76,7 +76,7 @@ private:
     EChatRole   role_;
     QLabel*     roleLabel_ = nullptr;     // 角色标签（"你" / "助手"）
     QTextEdit*  contentEdit_ = nullptr;   // 消息内容（支持富文本）
-    QString     accumulatedHtml_;          // 累积的 HTML（用于流式渲染 setHtml）
+    QString     accumulatedHtml_{};         // 累积的 HTML（用于流式渲染 setHtml）
     int         cachedDocHeight_ = 0;     // 上次计算的文档高度，避免循环
 };
 

--- a/src/AstUiAI/Chat/UiChatMessageList.hpp
+++ b/src/AstUiAI/Chat/UiChatMessageList.hpp
@@ -36,6 +36,8 @@ class AST_UIAI_API UiChatMessageList : public QWidget
 public:
     explicit UiChatMessageList(QWidget* parent = nullptr);
     ~UiChatMessageList() override;
+    UiChatMessageList(const UiChatMessageList&) = delete;
+    UiChatMessageList& operator=(const UiChatMessageList&) = delete;
 
     /// @brief 追加一条消息
     /// @return 新创建的消息部件指针

--- a/src/AstUiAI/Chat/UiChatPanel.hpp
+++ b/src/AstUiAI/Chat/UiChatPanel.hpp
@@ -112,8 +112,8 @@ private:
     UiChatMessageItem*      streamingItem_ = nullptr;   // 正在流式填充的助手消息
     UiToolCallTimeline*     toolTimeline_ = nullptr;    // 当前回合的工具调用时间线
     QTimer*                 throttleTimer_ = nullptr;   // 40ms 节流定时器
-    QString                 pendingHtml_;               // 累积的 HTML（定时器触发后一次性渲染）
-    std::string             accumulatedText_;            // 累积的流式文本
+    QString                 pendingHtml_{};               // 累积的 HTML（定时器触发后一次性渲染）
+    std::string             accumulatedText_{};            // 累积的流式文本
     bool                    busy_{false};
 };
 

--- a/src/AstUiAI/Chat/UiChatPanel.hpp
+++ b/src/AstUiAI/Chat/UiChatPanel.hpp
@@ -53,6 +53,8 @@ public:
     explicit UiChatPanel(ChatSession* session, QWidget* parent = nullptr);
 
     ~UiChatPanel() override;
+    UiChatPanel(const UiChatPanel&) = delete;
+    UiChatPanel& operator=(const UiChatPanel&) = delete;
 
     /// @brief 获取关联的聊天会话
     ChatSession* session() const { return session_; }

--- a/src/AstUiAI/Chat/UiChatWorker.hpp
+++ b/src/AstUiAI/Chat/UiChatWorker.hpp
@@ -77,7 +77,7 @@ private:
     QString             userMessage_;
     QPointer<UiChatEventHandler> handler_;
     int                 maxToolIterations_;
-    std::string         response_;
+    std::string         response_{}; 
     int                 errorCode_{0};
 };
 

--- a/src/AstUiAI/Chat/UiChatWorker.hpp
+++ b/src/AstUiAI/Chat/UiChatWorker.hpp
@@ -55,6 +55,9 @@ public:
 
     ~UiChatWorker() override;
 
+    UiChatWorker(const UiChatWorker&) = delete;
+    UiChatWorker& operator=(const UiChatWorker&) = delete;
+
     /// @brief 获取本轮对话的最终响应
     const std::string& response() const { return response_; }
 

--- a/src/AstUiAI/Chat/UiToolCallCard.hpp
+++ b/src/AstUiAI/Chat/UiToolCallCard.hpp
@@ -76,7 +76,7 @@ private:
     QString         toolCallId_;
     QString         functionName_;
     QString         arguments_;
-    QString         result_;
+    QString         result_{};
     EToolCallState  state_{EToolCallState::eRunning};
     bool            expanded_{false};
 

--- a/src/AstUiAI/Chat/UiToolCallCard.hpp
+++ b/src/AstUiAI/Chat/UiToolCallCard.hpp
@@ -51,6 +51,8 @@ public:
                             QWidget* parent = nullptr);
 
     ~UiToolCallCard() override;
+    UiToolCallCard(const UiToolCallCard&) = delete;
+    UiToolCallCard& operator=(const UiToolCallCard&) = delete;
 
     /// @brief 设置工具调用状态
     void setState(EToolCallState state);

--- a/src/AstUiAI/Chat/UiToolCallTimeline.hpp
+++ b/src/AstUiAI/Chat/UiToolCallTimeline.hpp
@@ -77,15 +77,15 @@ private:
 
     struct Entry
     {
-        QString toolCallId;
-        QString functionName;
-        QString arguments;
-        QString result;
+        QString toolCallId{};
+        QString functionName{};
+        QString arguments{};
+        QString result{};
         EToolCallState state{};
         bool    detailExpanded = false;
     };
 
-    QVector<Entry>  entries_;
+    QVector<Entry>  entries_{};
     bool            collapsed_ = true;
 
     // UI 部件

--- a/src/AstUiAI/Chat/UiToolCallTimeline.hpp
+++ b/src/AstUiAI/Chat/UiToolCallTimeline.hpp
@@ -41,6 +41,8 @@ class AST_UIAI_API UiToolCallTimeline : public QWidget
 public:
     explicit UiToolCallTimeline(QWidget* parent = nullptr);
     ~UiToolCallTimeline() override;
+    UiToolCallTimeline(const UiToolCallTimeline&) = delete;
+    UiToolCallTimeline& operator=(const UiToolCallTimeline&) = delete;
 
     /// @brief 添加一条工具调用条目
     /// @param toolCallId 工具调用 ID

--- a/src/AstUiAI/Integration/UiChatDockWidget.hpp
+++ b/src/AstUiAI/Integration/UiChatDockWidget.hpp
@@ -39,6 +39,8 @@ public:
     explicit UiChatDockWidget(ChatSession* session, QWidget* parent = nullptr);
 
     ~UiChatDockWidget() override;
+    UiChatDockWidget(const UiChatDockWidget&) = delete;
+    UiChatDockWidget& operator=(const UiChatDockWidget&) = delete;
 
     /// @brief 获取内部的聊天主控件
     UiChatMainWidget* chatWidget() const { return chatWidget_; }

--- a/src/AstUiDataUpdate/UiDataUpdate.cpp
+++ b/src/AstUiDataUpdate/UiDataUpdate.cpp
@@ -309,7 +309,7 @@ void UiDataUpdate::onUpdateAll()
     {
         std::atomic<int> done{0};
         std::atomic<int> success{0};
-        int total;
+        int total{};
     };
     auto ctx = std::make_shared<Context>();
     ctx->total = pending.size();

--- a/src/AstUiDataUpdate/UiDataUpdate.hpp
+++ b/src/AstUiDataUpdate/UiDataUpdate.hpp
@@ -37,6 +37,9 @@ public:
     explicit UiDataUpdate(QWidget* parent = nullptr);
     ~UiDataUpdate() override;
 
+    UiDataUpdate(const UiDataUpdate&) = delete;
+    UiDataUpdate& operator=(const UiDataUpdate&) = delete;
+
     /// @brief 取消所有进行中的更新任务（关闭对话框时调用）
     void reject() override;
 
@@ -52,7 +55,7 @@ private:
     void refreshTable();
     void setRowStatus(int row, const DataUpdater::DataFileEntry& entry);
 
-    DataUpdater         updater_;
+    DataUpdater         updater_{};
     std::atomic<bool>   cancelPending_{false};
     QTableWidget*  table_        = nullptr;
     QPushButton*   refreshBtn_   = nullptr;

--- a/src/AstUiPilot/PilotAgent.hpp
+++ b/src/AstUiPilot/PilotAgent.hpp
@@ -133,10 +133,10 @@ private:
     bool autoSnapshot_ = false;          ///< 是否自动生成快照
 
     // ---- ref 映射 ----
-    QHash<QWidget*, int> widgetToRef_;   ///< widget* → ref编号
-    QHash<int, QWidget*> refToWidget_;   ///< ref编号 → widget*
-    QHash<QAction*, int> actionToRef_;   ///< action* → ref编号
-    QHash<int, QAction*> refToAction_;   ///< ref编号 → action*
+    QHash<QWidget*, int> widgetToRef_{};   ///< widget* → ref编号
+    QHash<int, QWidget*> refToWidget_{};   ///< ref编号 → widget*
+    QHash<QAction*, int> actionToRef_{};   ///< action* → ref编号
+    QHash<int, QAction*> refToAction_{};   ///< ref编号 → action*
 
     int nextRef_ = 1;                    ///< 下一个可用的ref编号
     static PilotAgent* s_instance;      ///< 全局单例

--- a/src/AstUiPilot/PilotCommander.hpp
+++ b/src/AstUiPilot/PilotCommander.hpp
@@ -97,8 +97,8 @@ private:
     PilotSession*  session_;
     PilotRecorder* recorder_;
     std::atomic<bool> running_{true};
-    std::thread     stdinThread_;
-    std::function<void(const std::string&)> outputCb_;
+    std::thread     stdinThread_{};
+    std::function<void(const std::string&)> outputCb_{};
 };
 
 /*! @} */

--- a/src/AstUiPilot/PilotCommander.hpp
+++ b/src/AstUiPilot/PilotCommander.hpp
@@ -54,6 +54,8 @@ public:
 
     /// @brief 析构函数
     ~PilotCommander() override;
+    PilotCommander(const PilotCommander&) = delete;
+    PilotCommander& operator=(const PilotCommander&) = delete;
 
     /// @brief 执行命令字符串（线程安全）
     /// @param line 命令文本

--- a/src/AstUiPilot/PilotPipeServer.hpp
+++ b/src/AstUiPilot/PilotPipeServer.hpp
@@ -44,6 +44,8 @@ public:
     /// @param commander 命令调度器
     /// @param pid 目标进程 PID（用于构造唯一的 pipe 名称）
     explicit PilotPipeServer(PilotCommander* commander, unsigned long pid);
+    PilotPipeServer(const PilotPipeServer&) = delete;
+    PilotPipeServer& operator=(const PilotPipeServer&) = delete;
 
     /// @brief 析构函数，自动停止服务
     ~PilotPipeServer();
@@ -64,10 +66,10 @@ private:
     /// @brief 服务线程主循环
     void serverLoop();
 
-    PilotCommander*    commander_;
-    unsigned long      pid_;
+    PilotCommander*    commander_{};
+    unsigned long      pid_{};
     std::atomic<bool>  running_{false};
-    std::thread        serverThread_;
+    std::thread        serverThread_{};
 };
 
 /*! @} */

--- a/src/AstUiPilot/PilotPolisher.hpp
+++ b/src/AstUiPilot/PilotPolisher.hpp
@@ -23,6 +23,8 @@ class AST_UIPILOT_API PilotPolisher
 {
 public:
     PilotPolisher();
+    PilotPolisher(const PilotPolisher&) = delete;
+    PilotPolisher& operator=(const PilotPolisher&) = delete;
     ~PilotPolisher();
 
     /// @brief 对步骤列表进行 LLM 润色
@@ -34,7 +36,7 @@ public:
     static const char* systemPrompt();
 
 private:
-    ChatSession* chatSession_;
+    ChatSession* chatSession_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstUiPilot/PilotSession.cpp
+++ b/src/AstUiPilot/PilotSession.cpp
@@ -762,7 +762,6 @@ static std::string toolDrag(const JsonValue& args)
     if (!dstW) return "目标元素无效";
 
     QPoint srcPt = srcW->mapToGlobal(srcW->rect().center());
-    QPoint dstPt = dstW->mapToGlobal(dstW->rect().center());
     QTest::mousePress(srcW, Qt::LeftButton, Qt::NoModifier, srcW->rect().center());
     QTest::mouseMove(dstW, dstW->mapFromGlobal(srcPt));
     QTest::mouseMove(dstW, dstW->rect().center());

--- a/src/AstUiPilot/PilotSession.hpp
+++ b/src/AstUiPilot/PilotSession.hpp
@@ -48,6 +48,8 @@ public:
 
     /// @brief 析构函数
     ~PilotSession() override;
+    PilotSession(const PilotSession&) = delete;
+    PilotSession& operator=(const PilotSession&) = delete;
 
     /// @brief 执行自然语言指令
     /// @param command 用户指令

--- a/src/AstUiPilot/Player/PilotPlayer.hpp
+++ b/src/AstUiPilot/Player/PilotPlayer.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "AstGlobal.h"
-#include "../Recorder/RecordStep.hpp"
+#include "AstUiPilot/RecordStep.hpp"
 #include <QObject>
 #include <vector>
 #include <string>
@@ -68,11 +68,11 @@ private:
     void continuePlayback();  // 延迟继续
 
     PilotSession* session_;
-    std::vector<RecordStep> steps_;
+    std::vector<RecordStep> steps_{};
     int currentIndex_ = -1;
     bool running_ = false;
     bool paused_ = false;
-    std::string lastError_;
+    std::string lastError_{};
 };
 
 /*! @} */

--- a/src/AstUiPilot/Player/PilotPlayer.hpp
+++ b/src/AstUiPilot/Player/PilotPlayer.hpp
@@ -33,6 +33,8 @@ public:
 
     explicit PilotPlayer(PilotSession* session, QObject* parent = nullptr);
     ~PilotPlayer() override;
+    PilotPlayer(const PilotPlayer&) = delete;
+    PilotPlayer& operator=(const PilotPlayer&) = delete;
 
     // ---- 加载 ----
     bool loadScript(const std::string& filePath);

--- a/src/AstUiPilot/Recorder/PilotRecorder.hpp
+++ b/src/AstUiPilot/Recorder/PilotRecorder.hpp
@@ -90,8 +90,8 @@ private:
     void flushPendingEdit();
     void populateWidgetInfo(RecordStep& step, QWidget* w);
 
-    PilotAgent* agent_;
-    QList<RecordStep> steps_;
+    PilotAgent* agent_{};
+    QList<RecordStep> steps_{};
     bool recording_ = false;
     bool paused_    = false;
     int64_t startTime_ = 0;
@@ -99,15 +99,15 @@ private:
     // 双击检测
     QWidget* lastClickedWidget_ = nullptr;
     int clickCount_ = 0;
-    QElapsedTimer clickTimer_;
+    QElapsedTimer clickTimer_{};
 
     // 拖拽跟踪
     QWidget* dragSourceWidget_ = nullptr;
-    QString  dragSourceText_;
+    QString  dragSourceText_{};
 
     // 输入框编辑跟踪
     QWidget* editWidget_ = nullptr;
-    QString  editBeforeText_;
+    QString  editBeforeText_{};
 };
 
 /*! @} */

--- a/src/AstUiPilot/Recorder/PilotRecorder.hpp
+++ b/src/AstUiPilot/Recorder/PilotRecorder.hpp
@@ -42,6 +42,8 @@ class AST_UIPILOT_API PilotRecorder : public QObject
 public:
     explicit PilotRecorder(PilotAgent* agent, QObject* parent = nullptr);
     ~PilotRecorder() override;
+    PilotRecorder(const PilotRecorder&) = delete;
+    PilotRecorder& operator=(const PilotRecorder&) = delete;
 
     // ---- 生命周期 ----
     void start();

--- a/src/AstUiPilot/Recorder/RecordStep.hpp
+++ b/src/AstUiPilot/Recorder/RecordStep.hpp
@@ -68,16 +68,16 @@ inline ERecordAction recordActionFromString(const std::string& s)
 /// @brief 录制步骤结构
 struct RecordStep
 {
-    ERecordAction action;           ///< 操作类型
-    std::string   widgetClass;      ///< 控件类名
-    std::string   widgetText;       ///< 按钮文本 / 标签文本 / combo当前项
-    std::string   widgetObjName;    ///< Qt objectName
-    std::string   widgetAccName;    ///< accessibleName
-    std::string   parentInfo;       ///< 父控件描述
-    std::string   value;            ///< fill的值 / select的选项 / press的键名
+    ERecordAction action{};           ///< 操作类型
+    std::string   widgetClass{};      ///< 控件类名
+    std::string   widgetText{};       ///< 按钮文本 / 标签文本 / combo当前项
+    std::string   widgetObjName{};    ///< Qt objectName
+    std::string   widgetAccName{};    ///< accessibleName
+    std::string   parentInfo{};       ///< 父控件描述
+    std::string   value{};            ///< fill的值 / select的选项 / press的键名
     int64_t       timestampMs = 0;  ///< 相对录制开始的时间偏移
     int           siblingIndex = -1;///< 同级同类控件中的序号
-    std::string   naturalLanguage;  ///< 自然语言描述
+    std::string   naturalLanguage{};  ///< 自然语言描述
 
     /// @brief 生成模板描述
     std::string toTemplate() const;

--- a/src/AstUiPilot/UiPilotConsole.hpp
+++ b/src/AstUiPilot/UiPilotConsole.hpp
@@ -51,6 +51,8 @@ public:
 
     /// @brief 析构函数
     ~UiPilotConsole() override;
+    UiPilotConsole(const UiPilotConsole&) = delete;
+    UiPilotConsole& operator=(const UiPilotConsole&) = delete;
 
     /// @brief 向输出区域追加文本
     void appendOutput(const QString& text);

--- a/src/AstUiPilot/UiPilotToolbar.hpp
+++ b/src/AstUiPilot/UiPilotToolbar.hpp
@@ -73,34 +73,34 @@ private:
     void scrollToBottom();
     void rebuildStepListFromRecorder();
 
-    PilotCommander*  commander_;
-    PilotSession*    session_;
-    PilotRecorder*   recorder_;
+    PilotCommander*  commander_{};
+    PilotSession*    session_{};
+    PilotRecorder*   recorder_{};
     PilotPlayer*     player_ = nullptr;
 
     // 顶部
-    QLabel*          recIndicator_;
-    QLabel*          elapsedLabel_;
-    QLabel*          stepStatLabel_;
+    QLabel*          recIndicator_{};
+    QLabel*          elapsedLabel_{};
+    QLabel*          stepStatLabel_{};
 
     // 步骤
-    QListWidget*     stepList_;
+    QListWidget*     stepList_{};
 
     // 底部按钮
-    QPushButton*     recordBtn_;      // ⏺ 开始录制 / ⏹ 停止录制
-    QPushButton*     pauseBtn_;       // ⏸ 暂停 / ▶ 继续
-    QPushButton*     replayBtn_;      // ▶ 回放 / ⏹ 停止回放
-    QPushButton*     polishBtn_;      // 💎 润色
-    QPushButton*     copyBtn_;        // 📋 复制
+    QPushButton*     recordBtn_{};      // ⏺ 开始录制 / ⏹ 停止录制
+    QPushButton*     pauseBtn_{};       // ⏸ 暂停 / ▶ 继续
+    QPushButton*     replayBtn_{};      // ▶ 回放 / ⏹ 停止回放
+    QPushButton*     polishBtn_{};      // 💎 润色
+    QPushButton*     copyBtn_{};        // 📋 复制
 
     // 计时
-    QTimer*          elapsedTimer_;
-    QElapsedTimer    recordingStart_;
+    QTimer*          elapsedTimer_{};
+    QElapsedTimer    recordingStart_{};
     int              stepCount_  = 0;
     EState           state_      = EState::Idle;
 
     // 拖拽
-    QPoint           dragStartPos_;
+    QPoint           dragStartPos_{};
     bool             dragging_   = false;
 };
 

--- a/src/AstUiPilot/UiPilotToolbar.hpp
+++ b/src/AstUiPilot/UiPilotToolbar.hpp
@@ -33,6 +33,8 @@ public:
     explicit UiPilotToolbar(PilotCommander* commander, PilotSession* session,
                             PilotRecorder* recorder, QWidget* parent = nullptr);
     ~UiPilotToolbar() override;
+    UiPilotToolbar(const UiPilotToolbar&) = delete;
+    UiPilotToolbar& operator=(const UiPilotToolbar&) = delete;
 
 Q_SIGNALS:
     void consoleToggleRequested();

--- a/src/AstUiUtil/UiUtil.cpp
+++ b/src/AstUiUtil/UiUtil.cpp
@@ -41,6 +41,9 @@ public:
         if (sem_) sem_->release();
     }
 
+    CallableEvent(const CallableEvent&) = delete;
+    CallableEvent& operator=(const CallableEvent&) = delete;
+
 private:
     std::function<void()> func_;
     QSemaphore* sem_;

--- a/src/AstUtil/Builder/BuildTarget.hpp
+++ b/src/AstUtil/Builder/BuildTarget.hpp
@@ -162,13 +162,13 @@ public: // 编译、链接、构建、运行、打包等接口
     errc_t run();
     
 protected:
-    std::string name_;                     ///< 目标名称
+    std::string name_{};                    ///< 目标名称
     EKind kind_{EKind::eBinary};           ///< 目标类型
-    std::vector<std::string> files_;       ///< 源文件列表
-    std::vector<std::string> includeDirs_; ///< 包含目录列表
-    std::vector<std::string> linkDirs_;    ///< 链接目录列表
-    std::vector<std::string> defines_;     ///< 宏定义列表
-    std::vector<std::string> links_;       ///< 链接库列表
+    std::vector<std::string> files_{};      ///< 源文件列表
+    std::vector<std::string> includeDirs_{};///< 包含目录列表
+    std::vector<std::string> linkDirs_{};   ///< 链接目录列表
+    std::vector<std::string> defines_{};    ///< 宏定义列表
+    std::vector<std::string> links_{};      ///< 链接库列表
 };
 
 /*! @} */

--- a/src/AstUtil/Container/OrderedMap.hpp
+++ b/src/AstUtil/Container/OrderedMap.hpp
@@ -44,9 +44,9 @@ private:
     using map_type = std::unordered_map<Key, std::size_t>;
     
     // 按插入顺序存储键值对
-    vector_type items_;
+    vector_type items_{};
     // 键到下标位置的快速映射
-    map_type index_map_;
+    map_type index_map_{};
 public: // ---------- 迭代器支持 ----------
 
     using iterator = typename vector_type::iterator;

--- a/src/AstUtil/Container/VariantVector.hpp
+++ b/src/AstUtil/Container/VariantVector.hpp
@@ -231,8 +231,8 @@ private:
     void        copyFrom(const VariantVector& other);
     void        moveFrom(VariantVector& other) noexcept;
 
-    Header*       header()       noexcept;
-    const Header* header() const noexcept;
+    inline Header*       header()       noexcept;
+    inline const Header* header() const noexcept;
 
     /// @brief 确保类型已设置并校验一致性
     /// @tparam T 期望的元素类型

--- a/src/AstUtil/Identitifer/IdentifierTable.hpp
+++ b/src/AstUtil/Identitifer/IdentifierTable.hpp
@@ -36,7 +36,7 @@ AST_NAMESPACE_BEGIN
 class IdentifierTable {
 private:
     // 使用哈希表存储符号
-    std::unordered_multimap<size_t, std::unique_ptr<Identifier>> table_;
+    std::unordered_multimap<size_t, std::unique_ptr<Identifier>> table_{};
 #ifdef _AST_ENABLE_IDENTIFIER_TABLE_MUTEX
     mutable std::mutex mutex_;
 #endif

--- a/src/AstUtil/Network/Impl/NetworkImplWinHTTP.cxx
+++ b/src/AstUtil/Network/Impl/NetworkImplWinHTTP.cxx
@@ -102,6 +102,9 @@ public:
     Impl() : library_(nullptr) {
         loadLibrary();
     }
+
+    Impl(const Impl&) = delete;
+    Impl& operator=(const Impl&) = delete;
     
     ~Impl() {
         unloadLibrary();

--- a/src/AstUtil/Network/Impl/NetworkImplWinHTTP.hpp
+++ b/src/AstUtil/Network/Impl/NetworkImplWinHTTP.hpp
@@ -40,7 +40,10 @@ public:
     static NetworkImplWinHTTP* Instance();
     
     NetworkImplWinHTTP();
-    
+
+    NetworkImplWinHTTP(const NetworkImplWinHTTP&) = delete;
+    NetworkImplWinHTTP& operator=(const NetworkImplWinHTTP&) = delete;
+
     virtual ~NetworkImplWinHTTP();
     
     virtual errc_t requestStream(const NetworkRequest& request, NetworkStreamReceiver& receiver) override;

--- a/src/AstUtil/Network/Impl/NetworkImplWinINet.cpp
+++ b/src/AstUtil/Network/Impl/NetworkImplWinINet.cpp
@@ -97,7 +97,10 @@ public:
     Impl() : library_(nullptr) {
         loadLibrary();
     }
-    
+
+    Impl(const Impl&) = delete;
+    Impl& operator=(const Impl&) = delete;
+
     ~Impl() {
         unloadLibrary();
     }

--- a/src/AstUtil/Network/Impl/NetworkImplWinINet.hpp
+++ b/src/AstUtil/Network/Impl/NetworkImplWinINet.hpp
@@ -40,7 +40,10 @@ public:
     static NetworkImplWinINet* Instance();
 
     NetworkImplWinINet();
-    
+
+    NetworkImplWinINet(const NetworkImplWinINet&) = delete;
+    NetworkImplWinINet& operator=(const NetworkImplWinINet&) = delete;
+
     virtual ~NetworkImplWinINet();
 
 

--- a/src/AstUtil/Network/NetworkRequest.hpp
+++ b/src/AstUtil/Network/NetworkRequest.hpp
@@ -106,9 +106,9 @@ public:
 
 private:
     ENetworkRequestMethod method_{ENetworkRequestMethod::eGet};      ///< 网络请求方法
-    std::string url_;                                                ///< 网络请求 URL
-    std::string body_;                                               ///< 网络请求体
-    std::map<std::string, std::string> headers_;                     ///< 网络请求头
+    std::string url_{};                                               ///< 网络请求 URL
+    std::string body_{};                                              ///< 网络请求体
+    std::map<std::string, std::string> headers_{};                    ///< 网络请求头
 };
 
 /*! @} */

--- a/src/AstUtil/Network/NetworkResponse.hpp
+++ b/src/AstUtil/Network/NetworkResponse.hpp
@@ -74,8 +74,8 @@ public:
 
 private:
     int statusCode_ = 0;                         ///< 网络响应状态码码
-    std::string body_;                           ///< 网络响应体
-    std::map<std::string, std::string> headers_; ///< 网络响应头
+    std::string body_{};                          ///< 网络响应体
+    std::map<std::string, std::string> headers_{}; ///< 网络响应头
 };
 
 /*! @} */

--- a/src/AstUtil/Network/NetworkStreamReceiver.hpp
+++ b/src/AstUtil/Network/NetworkStreamReceiver.hpp
@@ -74,7 +74,7 @@ class AST_UTIL_API CollectingStreamReceiver : public NetworkStreamReceiver
 {
 public:
     explicit CollectingStreamReceiver(NetworkResponse& response)
-        : response_(response) {}
+        : response_(response), body_() {}
 
     void onHeaders(int statusCode,
                    const std::map<std::string, std::string>& headers) override

--- a/src/AstUtil/ParseFormat/BaseParser.hpp
+++ b/src/AstUtil/ParseFormat/BaseParser.hpp
@@ -56,6 +56,10 @@ class AST_UTIL_API BaseParser
 {
 public:
     BaseParser();
+
+    BaseParser(const BaseParser&) = delete;
+    BaseParser& operator=(const BaseParser&) = delete;
+
     explicit BaseParser(StringView filepath);
     ~BaseParser();
 
@@ -160,7 +164,7 @@ protected:
 private:
     FILE*             file_{nullptr};           ///< 文件指针
     bool              fileBorrowed_{false};     ///< 是否从外部借用文件指针
-    std::vector<char> lineBuffer_;               ///< 行缓冲区
+    std::vector<char> lineBuffer_{};              ///< 行缓冲区
 };
 
 

--- a/src/AstUtil/ParseFormat/BlockKeyValue/BKVBlock.hpp
+++ b/src/AstUtil/ParseFormat/BlockKeyValue/BKVBlock.hpp
@@ -33,7 +33,7 @@ AST_NAMESPACE_BEGIN
 class BKVBlock : public BKVNode
 {
 public:
-    BKVBlock() : BKVNode(eBlock) {}
+    BKVBlock() : BKVNode(eBlock), name_(), children_() {}
 private:
     std::string name_;      // 块名
     std::vector<std::unique_ptr<BKVNode>> children_;

--- a/src/AstUtil/ParseFormat/BlockKeyValue/BKVItem.hpp
+++ b/src/AstUtil/ParseFormat/BlockKeyValue/BKVItem.hpp
@@ -33,7 +33,7 @@ AST_NAMESPACE_BEGIN
 class BKVItem : public BKVNode
 {
 public:
-    BKVItem() : BKVNode(eItem) {}
+    BKVItem() : BKVNode(eItem), key_(), value_() {}
     /// @brief 键值对项节点（BlockKeyValueItemNode）
     BKVItem(StringView key, ValueView value)
         : BKVNode{eItem}

--- a/src/AstUtil/ParseFormat/BlockKeyValue/BKVItemView.hpp
+++ b/src/AstUtil/ParseFormat/BlockKeyValue/BKVItemView.hpp
@@ -45,8 +45,8 @@ public:
     ValueView& value()  { return value_; }
     
 public:
-    StringView key_;       ///< 键
-    ValueView value_;      ///< 值
+    StringView key_{};      ///< 键
+    ValueView value_{};     ///< 值
 };
 
 

--- a/src/AstUtil/ParseFormat/BlockKeyValue/BKVSaxPrint.hpp
+++ b/src/AstUtil/ParseFormat/BlockKeyValue/BKVSaxPrint.hpp
@@ -34,6 +34,10 @@ class AST_UTIL_API  BKVSaxPrint : public BKVSax
 {
 public:
     BKVSaxPrint();
+
+    BKVSaxPrint(const BKVSaxPrint&) = delete;
+    BKVSaxPrint& operator=(const BKVSaxPrint&) = delete;
+
     explicit BKVSaxPrint(StringView filepath);
     ~BKVSaxPrint();
     errc_t begin(StringView name) override;

--- a/src/AstUtil/ParseFormat/GenericValue.hpp
+++ b/src/AstUtil/ParseFormat/GenericValue.hpp
@@ -54,7 +54,7 @@ public:
     const std::string& value() const { return value_; }
     const char* c_str() const { return value_.c_str(); }
 protected:
-    std::string value_;
+    std::string value_{};
 };
 
 AST_NAMESPACE_END

--- a/src/AstUtil/ParseFormat/Json/JsonDomSax.cpp
+++ b/src/AstUtil/ParseFormat/Json/JsonDomSax.cpp
@@ -28,6 +28,7 @@ AST_NAMESPACE_BEGIN
 
 JsonDomSax::JsonDomSax(JsonValue& result)
     : error_(false)
+    , stack_()
     , internalResult_()
     , result_(result)
 {

--- a/src/AstUtil/ParseFormat/Json/JsonParser.hpp
+++ b/src/AstUtil/ParseFormat/Json/JsonParser.hpp
@@ -36,7 +36,7 @@ public:
 
 private:
     // ---- 缓冲区与游标 ----
-    std::vector<char> buffer_;      ///< 字符缓冲区（包含待解析内容）
+    std::vector<char> buffer_{};     ///< 字符缓冲区（包含待解析内容）
     size_t           currentPos_{0};///< 当前解析位置
 
     // ---- 文件读取 ----

--- a/src/AstUtil/ParseFormat/Json/JsonValue.cpp
+++ b/src/AstUtil/ParseFormat/Json/JsonValue.cpp
@@ -58,70 +58,69 @@ JsonValue JsonValue::FromFile(const StringView filePath)
 
 // 默认构造函数
 JsonValue::JsonValue()
-    : type_(EJsonValueType::eNull)
+    : type_(EJsonValueType::eNull), value_()
 {
-    value_.boolean_ = false; // 初始化联合体
 }
 
 // 布尔值构造函数
 JsonValue::JsonValue(bool value)
-    : type_(EJsonValueType::eBool)
+    : type_(EJsonValueType::eBool), value_()
 {
     value_.boolean_ = value;
 }
 
 // 整数构造函数
 JsonValue::JsonValue(int value)
-    : type_(EJsonValueType::eNumber)
+    : type_(EJsonValueType::eNumber), value_()
 {
     value_.number_ = static_cast<double>(value);
 }
 
 // 双精度浮点数构造函数
 JsonValue::JsonValue(double value)
-    : type_(EJsonValueType::eNumber)
+    : type_(EJsonValueType::eNumber), value_()
 {
     value_.number_ = value;
 }
 
 // 字符串构造函数（C字符串）
 JsonValue::JsonValue(const char* value)
-    : type_(EJsonValueType::eString)
+    : type_(EJsonValueType::eString), value_()
 {
     value_.string_ = new std::string(value);
 }
 
 // 字符串构造函数
 JsonValue::JsonValue(const std::string& value)
-    : type_(EJsonValueType::eString)
+    : type_(EJsonValueType::eString), value_()
 {
     value_.string_ = new std::string(value);
 }
 
 // 字符串视图构造函数
 JsonValue::JsonValue(StringView value)
-    : type_(EJsonValueType::eString)
+    : type_(EJsonValueType::eString), value_()
 {
     value_.string_ = new std::string(value.data(), value.size());
 }
 
 // 数组构造函数
 JsonValue::JsonValue(const std::vector<JsonValue>& values)
-    : type_(EJsonValueType::eArray)
+    : type_(EJsonValueType::eArray), value_()
 {
     value_.array_ = new std::vector<JsonValue>(values);
 }
 
 // 对象构造函数
 JsonValue::JsonValue(const std::map<std::string, JsonValue>& values)
-    : type_(EJsonValueType::eObject)
+    : type_(EJsonValueType::eObject), value_()
 {
     value_.object_ = new std::map<std::string, JsonValue>(values);
 }
 
 // 拷贝构造函数
 JsonValue::JsonValue(const JsonValue& other)
-    : type_(other.type_)
+    : type_(other.type_), value_()
 {
     switch (type_)
     {
@@ -148,7 +147,7 @@ JsonValue::JsonValue(const JsonValue& other)
 
 // 移动构造函数
 JsonValue::JsonValue(JsonValue&& other) noexcept
-    : type_(other.type_)
+    : type_(other.type_), value_()
 {
     value_ = other.value_;
     other.value_ = {};

--- a/src/AstUtil/ParseFormat/Markdown/MarkdownANSI.hpp
+++ b/src/AstUtil/ParseFormat/Markdown/MarkdownANSI.hpp
@@ -145,13 +145,13 @@ private:
     };
 
     // ---- 输出缓冲 ----
-    std::string output_;
+    std::string output_{};
 
     // ---- 行内状态 ----
     int activeStyles_ = STYLE_NONE;
 
     // ---- 块级状态 ----
-    std::vector<BlockFrame> blockStack_;
+    std::vector<BlockFrame> blockStack_{};
 
     /// @brief 列表栈帧（支持嵌套列表的逐级编号与缩进）
     struct ListFrame
@@ -159,7 +159,7 @@ private:
         bool ordered;       ///< true=有序, false=无序
         int  itemNumber;    ///< 当前级已输出的列表项序号（0=尚未开始第一项）
     };
-    std::vector<ListFrame> listStack_;
+    std::vector<ListFrame> listStack_{};
 
     bool inCodeBlock_    = false;
     int  codeLineNumber_ = 0;
@@ -167,13 +167,13 @@ private:
     // ---- 表格缓冲 ----
     struct CellData
     {
-        std::string rendered;   ///< ANSI 渲染后的内容（含转义序列）
+        std::string rendered{};  ///< ANSI 渲染后的内容（含转义序列）
         int         width = 0;  ///< 净显示宽度（剔除转义序列后）
         ETableAlign align = ETableAlign::eDefault;
     };
     struct RowData
     {
-        std::vector<CellData> cells;
+        std::vector<CellData> cells{};
         bool isHeader = false;
     };
 
@@ -181,13 +181,13 @@ private:
     bool   inTableHead_   = false;   ///< 当前是否在表头区域
     bool   inCell_        = false;   ///< 当前是否在 cell 内（inline 事件重定向到 cellContent_）
     ETableAlign cellAlign_ = ETableAlign::eDefault;  ///< 当前 cell 对齐方式
-    std::string cellContent_;        ///< cell 内容缓冲（独立于 output_，跨 chunk 不丢失）
+    std::string cellContent_{};       ///< cell 内容缓冲（独立于 output_，跨 chunk 不丢失）
     bool   truncateCells_ = true;     ///< 是否截断超出列宽的单元格（默认开启）
-    RowData currentRow_;             ///< 当前行缓冲
-    std::vector<RowData> tableRows_; ///< 表格所有行（含表头）
+    RowData currentRow_{};            ///< 当前行缓冲
+    std::vector<RowData> tableRows_{}; ///< 表格所有行（含表头）
 
     // ---- 链接状态 ----
-    std::string linkUrl_;
+    std::string linkUrl_{};
 };
 
 /*! @} */

--- a/src/AstUtil/ParseFormat/Markdown/MarkdownBlockParser.hpp
+++ b/src/AstUtil/ParseFormat/Markdown/MarkdownBlockParser.hpp
@@ -131,14 +131,14 @@ private:
     std::unique_ptr<MarkdownTableParser> tableSM_;
 
     EState state_ = EState::eLineStart;
-    std::vector<BlockFrame> blockStack_;
+    std::vector<BlockFrame> blockStack_{};
 
     // 分类缓冲（行首判定用，最多缓冲几个字符）
-    std::string classBuf_;
+    std::string classBuf_{};
     // 行内内容缓冲（分类确认后，累积待喂入 inlineSM 的内容）
-    std::string contentBuf_;
+    std::string contentBuf_{};
     // 代码块行缓冲（仅代码块内逐行检测关界围栏）
-    std::string codeLineBuf_;
+    std::string codeLineBuf_{};
 
     // ---- 标题状态 ----
     int headingLevel_ = 0;
@@ -146,7 +146,7 @@ private:
     // ---- 代码围栏状态 ----
     char codeFenceChar_ = 0;
     int  codeFenceCount_ = 0;
-    std::string codeFenceLang_;
+    std::string codeFenceLang_{};
 
     // ---- 列表状态 ----
     bool inList_           = false;

--- a/src/AstUtil/ParseFormat/Markdown/MarkdownHTML.hpp
+++ b/src/AstUtil/ParseFormat/Markdown/MarkdownHTML.hpp
@@ -126,13 +126,13 @@ private:
     void appendNewline();
 
     // ---- 输出缓冲 ----
-    std::string output_;
+    std::string output_{};
 
     // ---- 格式化控制 ----
     bool compact_ = false;              ///< true=紧凑输出，false=格式化输出
 
     // ---- 块级状态 ----
-    std::vector<bool> listStack_;   ///< 列表类型栈: true=有序, false=无序
+    std::vector<bool> listStack_{}; ///< 列表类型栈: true=有序, false=无序
     int  blockquoteDepth_ = 0;      ///< 块引用嵌套深度
     int  lastEndListDepth_ = -1;    ///< 最近一次 endList 后的栈深度，用于 endListItem 判断子列表换行
 
@@ -140,7 +140,7 @@ private:
     bool inTableHead_ = false;      ///< 当前是否在表头区域内
 
     // ---- 链接状态 ----
-    std::string linkUrl_;
+    std::string linkUrl_{};
 };
 
 

--- a/src/AstUtil/ParseFormat/Markdown/MarkdownInlineParser.hpp
+++ b/src/AstUtil/ParseFormat/Markdown/MarkdownInlineParser.hpp
@@ -118,10 +118,10 @@ private:
     char emphDelim_   = 0;                             ///< 打开当前斜体的定界符类型（* 或 _）
     EStateFlags pendingState_ = EStateFlags::ePlain;    ///< 待处理格式位掩码
     EParseMode  mode_ = EParseMode::eNormal;            ///< 当前解析模式
-    std::string result_;                                ///< feed(StringView) 的输出缓冲
-    std::string linkText_;                              ///< 链接文本 / 图片 Alt 缓冲
-    std::string linkUrl_;                               ///< 链接 URL / 图片 URL 缓冲
-    std::string codeBuf_;                               ///< 行内代码内容缓冲
+    std::string result_{};                               ///< feed(StringView) 的输出缓冲
+    std::string linkText_{};                             ///< 链接文本 / 图片 Alt 缓冲
+    std::string linkUrl_{};                              ///< 链接 URL / 图片 URL 缓冲
+    std::string codeBuf_{};                              ///< 行内代码内容缓冲
     char   delimRunChar_ = 0;                           ///< 当前待提交定界符游程的类型（* 或 _, 0 = 无）
     int    delimRunLen_ = 0;                            ///< 当前待提交定界符游程的长度
     char   runPrevChar_ = 0;                            ///< 紧邻定界符游程之前的字符

--- a/src/AstUtil/ParseFormat/Markdown/MarkdownTableParser.cpp
+++ b/src/AstUtil/ParseFormat/Markdown/MarkdownTableParser.cpp
@@ -17,6 +17,7 @@ AST_NAMESPACE_BEGIN
 MarkdownTableParser::MarkdownTableParser(MarkdownSax& sax)
     : sax_(sax)
     , inlineSM_(sax)
+    , rowBuf_(), headerCells_(), colAligns_(), abortBuf_()
 {
 }
 

--- a/src/AstUtil/ParseFormat/Markdown/MarkdownTableParser.hpp
+++ b/src/AstUtil/ParseFormat/Markdown/MarkdownTableParser.hpp
@@ -133,16 +133,16 @@ private:
     bool charConsumed_ = true;
 
     // 行缓冲（逐字符累积，\n 时处理并清空）
-    std::string rowBuf_;
+    std::string rowBuf_{};
 
     // 表头缓冲（分隔行确认前暂存）
-    std::vector<std::string> headerCells_;
+    std::vector<std::string> headerCells_{};
 
     // 列对齐（分隔行解析后确定）
-    std::vector<ETableAlign> colAligns_;
+    std::vector<ETableAlign> colAligns_{};
 
     // 回退文本（表格未确认时，累积的原始行文本，用于回退为段落）
-    std::string abortBuf_;
+    std::string abortBuf_{};
 };
 
 

--- a/src/AstUtil/ParseFormat/ParseFormat.cpp
+++ b/src/AstUtil/ParseFormat/ParseFormat.cpp
@@ -32,7 +32,14 @@
 #include <cmath>
 
 #ifdef AST_WITH_FMT
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#endif
 #include <fmt/format.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #ifdef AST_WITH_ABSEIL

--- a/src/AstUtil/ParseFormat/SpiceParser/PCKParser.cpp
+++ b/src/AstUtil/ParseFormat/SpiceParser/PCKParser.cpp
@@ -30,7 +30,7 @@ static_assert(sizeof(std::vector<double>) == sizeof(std::vector<int>), "std::vec
 PCKParser::PCKParser()
     : BaseParser()
     , keyBuffer_(1024)
-    //, valueBuffer_(2048)
+    , valueBuffer_()
     , inDataBlock_(false)
 {
 
@@ -39,7 +39,7 @@ PCKParser::PCKParser()
 PCKParser::PCKParser(StringView filepath)
     : BaseParser(filepath)
     , keyBuffer_(1024)
-    // , valueBuffer_(2048)
+    , valueBuffer_()
     , inDataBlock_(false)
 {
 

--- a/src/AstUtil/ParseFormat/SpiceParser/SPKParser.cpp
+++ b/src/AstUtil/ParseFormat/SpiceParser/SPKParser.cpp
@@ -189,10 +189,12 @@ struct SPK_Type20_Trailer {
 #pragma pack(pop)
 
 SPKParser::SPKParser()
+    : spkDescriptors_(), buffer_()
 {
 }
 
 SPKParser::SPKParser(StringView filepath)
+    : spkDescriptors_(), buffer_()
 {
     parse(filepath);
 }

--- a/src/AstUtil/ParseFormat/ValueView.hpp
+++ b/src/AstUtil/ParseFormat/ValueView.hpp
@@ -126,7 +126,7 @@ public:
         value_, DelimiterType(delimiter), strings_internal::AllowEmpty());
     }
 public:
-    StringView  value_;
+    StringView  value_{};
 };
 
 

--- a/src/AstUtil/ParseFormat/XML/XMLDomSax.cpp
+++ b/src/AstUtil/ParseFormat/XML/XMLDomSax.cpp
@@ -24,8 +24,8 @@
 
 AST_NAMESPACE_BEGIN
 
-XMLDomSax::XMLDomSax(XMLNode& root) 
-    : root_(root) {
+XMLDomSax::XMLDomSax(XMLNode& root)
+    : root_(root), nodeStack_() {
 }
 
 XMLDomSax::~XMLDomSax() {

--- a/src/AstUtil/ParseFormat/XML/XMLNode.hpp
+++ b/src/AstUtil/ParseFormat/XML/XMLNode.hpp
@@ -161,8 +161,8 @@ private:
 private:
     EXMLNodeType kind_{EXMLNodeType::eElement};      ///< 节点类型
     std::string nameOrText_{};                       ///< 节点名称或文本
-    std::vector<HXMLNode> children_;                 ///< 子节点列表
-    std::map<std::string, GenericValue> attributes_; ///< 属性列表
+    std::vector<HXMLNode> children_{};                ///< 子节点列表
+    std::map<std::string, GenericValue> attributes_{}; ///< 属性列表
 };
 
 /*! @} */

--- a/src/AstUtil/ParseFormat/XML/XMLParser.hpp
+++ b/src/AstUtil/ParseFormat/XML/XMLParser.hpp
@@ -134,11 +134,11 @@ private: // XML 片段解析函数
     void skipWhitespace();
 private:
     size_t pos_{0};                        ///< 当前解析位置
-    std::vector<char> buffer_;             ///< 缓冲区
-    XMLSax::AttributeList attributes_;     ///< 属性列表
-    StringView nameOrText_;                ///< 元素名称或文本内容
+    std::vector<char> buffer_{};           ///< 缓冲区
+    XMLSax::AttributeList attributes_{};   ///< 属性列表
+    StringView nameOrText_{};              ///< 元素名称或文本内容
     bool selfClosingTag_{false};           ///< 自闭合标签标志
-    std::string unescapedText_;            ///< 未转义的文本内容
+    std::string unescapedText_{};          ///< 未转义的文本内容
 };
 
 

--- a/src/AstUtil/Platform/FileSystemSimple.cpp
+++ b/src/AstUtil/Platform/FileSystemSimple.cpp
@@ -145,6 +145,10 @@ namespace fs_simple
         {
             
         }
+
+        impl(const impl&) = delete;
+        impl& operator=(const impl&) = delete;
+        
         bool valid() const
         {
             return direntry != nullptr;

--- a/src/AstUtil/Platform/FileSystemSimple.cpp
+++ b/src/AstUtil/Platform/FileSystemSimple.cpp
@@ -57,12 +57,15 @@ namespace fs_simple
         path base_path; 
         bool data_valid;
     
-        impl(const path& p) 
+        impl(const path& p)
             : handle(INVALID_HANDLE_VALUE)
             , base_path(p)
             , data_valid{false}
         {
         }
+
+        impl(const impl&) = delete;
+        impl& operator=(const impl&) = delete;
 
         bool valid() const
         {
@@ -195,8 +198,8 @@ namespace fs_simple
     };
 #endif
 
-    directory_iterator::directory_iterator(const path& p) 
-        : impl_(std::make_shared<impl>(p))
+    directory_iterator::directory_iterator(const path& p)
+        : impl_(std::make_shared<impl>(p)), entry_()
     {
         if (impl_->first())
         {

--- a/src/AstUtil/Platform/FileSystemSimple.hpp
+++ b/src/AstUtil/Platform/FileSystemSimple.hpp
@@ -204,7 +204,7 @@ namespace fs_simple
             return (path_);
         }
     private:
-        string_type path_;
+        string_type path_{};
     };
 
     // 文件类型枚举
@@ -252,14 +252,14 @@ namespace fs_simple
         AST_UTIL_API
         file_status status() const;
     private:
-        _AST_FS path path_;
+        _AST_FS path path_{};
     };
 
     // 目录迭代器
     class AST_UTIL_API directory_iterator
     {
     public:
-        directory_iterator() : impl_(nullptr)
+        directory_iterator() : impl_(nullptr), entry_()
         {}
         explicit directory_iterator(const path& p);
         ~directory_iterator() = default;

--- a/src/AstUtil/Quantity/Unit.cpp
+++ b/src/AstUtil/Quantity/Unit.cpp
@@ -402,6 +402,7 @@ void aUnitFactorize(Unit &unit, double &scale)
 }
 
 Unit::Unit(StringView name)
+    : rep_()
 {
     errc_t err = aUnitParse(name, *this);
     if(err != 0)

--- a/src/AstUtil/Quantity/UnitManager.hpp
+++ b/src/AstUtil/Quantity/UnitManager.hpp
@@ -117,8 +117,8 @@ protected:
 
     Unit* _getSiUnitCache(Dimension dim);
 protected:
-    std::unordered_map<std::string, Unit*> units_;       ///< 单位映射表
-    std::map<Dimension, Unit*> siUnits_;                 ///< 国际制单位映射表
+    std::unordered_map<std::string, Unit*> units_{};      ///< 单位映射表
+    std::map<Dimension, Unit*> siUnits_{};                ///< 国际制单位映射表
 };
 
 /*! @} */

--- a/src/AstUtil/RTTI/ClassRegistry.hpp
+++ b/src/AstUtil/RTTI/ClassRegistry.hpp
@@ -53,7 +53,7 @@ public:
     void registerClass(Class* cls);
     void registerClass(Class* cls, StringView name);
 protected:
-    ClassMap classMap_;
+    ClassMap classMap_{};
 };
 
 #endif

--- a/src/AstUtil/RTTI/ObjectLinkTo.hpp
+++ b/src/AstUtil/RTTI/ObjectLinkTo.hpp
@@ -39,6 +39,10 @@ public:
     AST_OBJECT(ObjectLinkTo)
 
     ObjectLinkTo() = default;
+
+    ObjectLinkTo(const ObjectLinkTo&) = delete;
+    ObjectLinkTo& operator=(const ObjectLinkTo&) = delete;
+
     ~ObjectLinkTo() = default;
 
     void setResolvedName(const std::string& name);
@@ -51,8 +55,8 @@ public:
     
     Object* resolve() const;
 private:
-    mutable WeakPtr<Object> resolvedObject_;        ///< 已解析的对象
-    std::string resolvedName_;                      ///< 用于解析的名称
+    mutable WeakPtr<Object> resolvedObject_{};        ///< 已解析的对象
+    std::string resolvedName_{};                      ///< 用于解析的名称
     Class* resolvedType_{nullptr};                  ///< 用于解析的类型
 };
 

--- a/src/AstUtil/RTTI/ObjectLinker.cpp
+++ b/src/AstUtil/RTTI/ObjectLinker.cpp
@@ -31,7 +31,7 @@ AST_NAMESPACE_BEGIN
 class ObjectLinkerManager
 {
 public:
-    ObjectLinkerManager() = default;
+    ObjectLinkerManager() : linkers_() {}
 
     ~ObjectLinkerManager() = default;
 

--- a/src/AstUtil/RTTI/ObjectManager.hpp
+++ b/src/AstUtil/RTTI/ObjectManager.hpp
@@ -137,7 +137,7 @@ protected:
 protected:
     constexpr static uint32_t kDefaultMaxObjectCount = static_cast<uint32_t>(-1) - 1;
 
-    std::vector<ObjectNode*> objects_;                      ///< 所有对象节点
+    std::vector<ObjectNode*> objects_{};                      ///< 所有对象节点
     uint32_t nextIndex_{0};                                 ///< 下一个索引
     uint32_t maxObjectCount_{kDefaultMaxObjectCount};       ///< 最大对象数量
 };

--- a/src/AstUtil/RTTI/ObjectNamed.hpp
+++ b/src/AstUtil/RTTI/ObjectNamed.hpp
@@ -50,7 +50,7 @@ public:
     /// @brief 设置对象名称
     void setName(StringView name) override { name_ = std::string(name); }
 private:
-    std::string name_;      ///< 对象名称
+    std::string name_{};      ///< 对象名称
 };
 
 

--- a/src/AstUtil/RTTI/ObjectNode.hpp
+++ b/src/AstUtil/RTTI/ObjectNode.hpp
@@ -38,8 +38,13 @@ class AST_UTIL_API ObjectNode
 {
 public:
     ObjectNode() = default;
+
+    ObjectNode(const ObjectNode&) = delete;
+    ObjectNode& operator=(const ObjectNode&) = delete;
+
     explicit ObjectNode(Object* object)
         : object_(object)
+        , children_()
     {}
     friend class ObjectManager;
     ~ObjectNode() = default;

--- a/src/AstUtil/RTTI/Reflect/Attribute/Attribute.hpp
+++ b/src/AstUtil/RTTI/Reflect/Attribute/Attribute.hpp
@@ -58,7 +58,10 @@ public:
     typedef typename object_ptr_holder<object_type>::type object_ptr_holder_type;
 
     AttributeBasic() = default;
-    
+
+    AttributeBasic(const AttributeBasic&) = default;
+    AttributeBasic& operator=(const AttributeBasic&) = default;
+
     AttributeBasic(ObjectType* object, PropertyType* property)
         : object_(object)
         , property_(property)

--- a/src/AstUtil/RTTI/Reflect/Class.hpp
+++ b/src/AstUtil/RTTI/Reflect/Class.hpp
@@ -46,6 +46,9 @@ public:
 
     using Struct::Struct;
 
+    Class(const Class&) = delete;
+    Class& operator=(const Class&) = delete;
+
     /// @brief 构造函数
     /// @param parent 父类指针
     explicit Class(Class* parent = nullptr);

--- a/src/AstUtil/RTTI/Reflect/Class.hpp
+++ b/src/AstUtil/RTTI/Reflect/Class.hpp
@@ -46,8 +46,8 @@ public:
 
     using Struct::Struct;
 
-    Class(const Class&) = delete;
-    Class& operator=(const Class&) = delete;
+    Class(const Class&) = default;
+    Class& operator=(const Class&) = default;
 
     /// @brief 构造函数
     /// @param parent 父类指针

--- a/src/AstUtil/RTTI/Reflect/Field.hpp
+++ b/src/AstUtil/RTTI/Reflect/Field.hpp
@@ -33,7 +33,7 @@ AST_NAMESPACE_BEGIN
 class AST_UTIL_API Field
 {
 public:
-    Field(){}
+    Field() : name_(), desc_() {}
 
     explicit Field(StringView name, StringView desc = "")
         : name_(name), desc_(desc)

--- a/src/AstUtil/RTTI/Reflect/PropertyObject.hpp
+++ b/src/AstUtil/RTTI/Reflect/PropertyObject.hpp
@@ -40,6 +40,10 @@ public:
     using OutputType = Object*;
 public:
     PropertyObject() = default;
+
+    PropertyObject(const PropertyObject&) = delete;
+    PropertyObject& operator=(const PropertyObject&) = delete;
+
     PropertyObject(FPropertyGet getter, FPropertySet setter, Class* cls);
 
     errc_t getValueBool(const void* container, bool& value) override;

--- a/src/AstUtil/RTTI/Reflect/Struct.hpp
+++ b/src/AstUtil/RTTI/Reflect/Struct.hpp
@@ -39,6 +39,10 @@ class AST_UTIL_API Struct: public Object
 public:
     Struct()
         : Object(initial_strong_ref)
+        , name_()
+        , desc_()
+        , properties_()
+        , propertyMap_()
     {
         this->setReadOnly(true);
     }

--- a/src/AstUtil/String/Encode.cpp
+++ b/src/AstUtil/String/Encode.cpp
@@ -89,6 +89,10 @@ class LocaleHolder
 {
 public:
     LocaleHolder() = default;
+
+    LocaleHolder(const LocaleHolder&) = delete;
+    LocaleHolder& operator=(const LocaleHolder&) = delete;
+
     explicit LocaleHolder(_locale_t locale)
         : locale_(locale)
     {

--- a/src/AstUtil/Util/LocaleGuard.hpp
+++ b/src/AstUtil/Util/LocaleGuard.hpp
@@ -72,9 +72,9 @@ public:
     A_DISABLE_COPY(LocaleGuard);
 
 private:
-    bool active_;            // 是否需要在析构时恢复
-    int category_;           // 影响哪个 locale 类别（LC_ALL, LC_CTYPE 等）
-    std::string old_locale_; // 保存的原 locale 字符串
+    bool active_{};           // 是否需要在析构时恢复
+    int category_{};          // 影响哪个 locale 类别（LC_ALL, LC_CTYPE 等）
+    std::string old_locale_{};// 保存的原 locale 字符串
 };
 
 /*! @} */

--- a/src/AstUtil/Util/Polynomial.hpp
+++ b/src/AstUtil/Util/Polynomial.hpp
@@ -103,7 +103,7 @@ public:
     /// @return 函数值
     double eval(double x) const;
 protected:
-    std::vector<double> coeffs_;
+    std::vector<double> coeffs_{};
 };
 
 

--- a/src/AstUtil/Util/StartupConfig.hpp
+++ b/src/AstUtil/Util/StartupConfig.hpp
@@ -111,8 +111,8 @@ protected:
     std::string decodeConfig(StringView value);
 protected:
     using ConfigMap = std::unordered_map<std::string, GenericValue>;
-    ConfigMap configMap_;
-    std::string filepath_;
+    ConfigMap configMap_{};
+    std::string filepath_{};
 };
 
 

--- a/src/AstUtil/Util/Version.cpp
+++ b/src/AstUtil/Util/Version.cpp
@@ -125,6 +125,7 @@ namespace
 }  // anonymous namespace
 
 Version::Version(StringView version)
+    : prerelease_(), build_()
 {
     *this = Parse(version);
 }

--- a/src/AstUtil/Util/Version.hpp
+++ b/src/AstUtil/Util/Version.hpp
@@ -89,8 +89,8 @@ private:
     int major_{-1};                 ///< 主版本号
     int minor_{0};                  ///< 次版本号
     int patch_{0};                  ///< 修订版本号
-    std::string prerelease_;        ///< 预发布版本号
-    std::string build_;             ///< 构建版本号
+    std::string prerelease_{};       ///< 预发布版本号
+    std::string build_{};            ///< 构建版本号
 };
 
 /*! @} */

--- a/src/AstUtil/Util/WorkingDirectory.hpp
+++ b/src/AstUtil/Util/WorkingDirectory.hpp
@@ -39,6 +39,7 @@ class WorkingDirectory
 {
 public:
     explicit WorkingDirectory(StringView path)
+        : oldpath_(), curpath_()
     {
         oldpath_ = posix::getcwd();
         /// @todo 需要考虑如何避免创建临时std::string对象 

--- a/src/AstUtil/xmake.lua
+++ b/src/AstUtil/xmake.lua
@@ -9,4 +9,8 @@
     add_headerfiles("../../include/AstGlobal.h")
     add_headerfiles("../../include/AstCompiler.h")
     add_defines("AST_BUILD_LIB_UTIL")
-    -- add_extrafiles("xmake.lua")    
+    -- add_extrafiles("xmake.lua")   
+    if is_plat("linux") then
+        add_syslinks("dl")
+    end
+

--- a/src/AstWeather/Magnetosphere/aep8/aep8.cpp
+++ b/src/AstWeather/Magnetosphere/aep8/aep8.cpp
@@ -145,6 +145,7 @@ errc_t AEP8Data::load(StringView filepath)
 }
 
 AEPDataCollection::AEPDataCollection()
+    : ae8max_(), ae8min_(), ap8min_(), ap8max_()
 {
     errc_t rc = loadDefault();
     if(rc)

--- a/src/xmake.lua
+++ b/src/xmake.lua
@@ -5,6 +5,17 @@ if is_plat("windows") and is_mode("debug") then
     set_suffixname("D") -- windows的调试库使用D后缀
 end
 
+-- for gcc: 将一些警告转换为错误，以发现潜在的问题
+if is_plat("linux") or is_plat("mingw") then
+    add_cxflags("-Werror=uninitialized")
+    add_cxflags("-Werror=init-self")
+    add_cxflags("-Werror=maybe-uninitialized")
+    add_cxflags("-Werror=missing-field-initializers")
+    -- C++ 专用警告
+    add_cxxflags("-Werror=effc++")
+    add_cxxflags("-Werror=reorder")
+end
+
 -- if is_plat("windows") then
 --     add_cxflags("/utf-8")
 -- end

--- a/xmake.lua
+++ b/xmake.lua
@@ -2,7 +2,7 @@
 set_project("ast")
 
 -- 设置版本号
-set_version("0.0.1", {build="%Y%m%d"})
+set_version("0.2.0", {build="%Y%m%d"})
 
 -- 工程配置选项：是否编译测试工程
 option("with_test")


### PR DESCRIPTION
## 变更概述

本 PR 包含一系列代码质量修复，主要涉及以下方面：

### 类成员初始化
- 为多个类中未初始化的成员变量添加默认初始化值
- 禁用不完整的拷贝构造函数和拷贝赋值运算符

### 编译器警告修复
- 启用 GCC 编译警告并修复相关警告信息
- 抑制部分不必要的编译器警告

### constexpr 兼容性
- 将  运算符替换为  以确保 constexpr 上下文的兼容性

## 提交记录

- `f02b927` fix: replace || with | for constexpr compatibility
- `c052b88` fix: initialize members and move gcc warnings
- `33fbf4b` fix: initialize members and suppress warnings
- `850130b` fix: initialize class members and disable copy
- `e642e48` fix: initialize class members and disable copy
- `d16f63a` fix: disable copy and initialize ODE members
- `66ef935` fix: enable C++ warnings and initialize class members
- `36d8dbe` fix: enable gcc warnings and initialize class members